### PR TITLE
Test Run Call Logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 **HEAVY WORK IN PROGRESS**
 
 ```
+$ forge --help
+
 The command line client "forge" to StormForger offers a interface
 to the StormForger API and several convenience methods
 to handle load and performance tests.
@@ -22,6 +24,7 @@ Available Commands:
   har         Convert HAR to test case
   login       Login to StormForger
   ping        Ping the StormForger API
+  test-run    Work with and manage test runs
   version     Show forge version
 
 Flags:

--- a/api/testrun.go
+++ b/api/testrun.go
@@ -20,11 +20,11 @@ type testRunResources struct {
 func (c *Client) TestRunCallLog(pathID string, preview bool) (io.ReadCloser, error) {
 	testRun := extractResources(pathID)
 
-	path := ""
+	var path string
 	if testRun.uid == "" {
-		path = "/test_cases/" + testRun.organisation + "/" + testRun.testCase + "/test_runs/" + testRun.sequenceID
+		path = "/beta/test_cases/" + testRun.organisation + "/" + testRun.testCase + "/test_runs/" + testRun.sequenceID
 	} else {
-		path = "/t/" + testRun.uid
+		path = "/beta/t/" + testRun.uid
 	}
 
 	path += "/call_log"
@@ -41,6 +41,8 @@ func (c *Client) TestRunCallLog(pathID string, preview bool) (io.ReadCloser, err
 	// TODO how to set these on all requests?
 	req.Header.Add("Authorization", "Bearer "+c.JWT)
 	req.Header.Set("User-Agent", c.UserAgent)
+
+	req.Header.Set("Accept-Encoding", "gzip")
 
 	response, err := c.HTTPClient.Do(req)
 	if err != nil {

--- a/api/testrun.go
+++ b/api/testrun.go
@@ -1,0 +1,90 @@
+package api
+
+import (
+	"errors"
+	"io/ioutil"
+	"net/http"
+	"strings"
+)
+
+type testRunResources struct {
+	uid          string
+	organisation string
+	testCase     string
+	sequenceID   string
+}
+
+// TestRunCallLogPreview will download the first 10k lines
+// of the test run's call log
+func (c *Client) TestRunCallLogPreview(pathID string) (string, error) {
+	testRun := extractResources(pathID)
+
+	path := ""
+	if testRun.uid == "" {
+		path = "/test_cases/" + testRun.organisation + "/" + testRun.testCase + "/test_runs/" + testRun.sequenceID
+	} else {
+		path = "/t/" + testRun.uid
+	}
+
+	// pathID looks like foo/demo/test_runs/19
+	req, err := http.NewRequest("GET", c.APIEndpoint+path+"/call_log_preview", nil)
+	if err != nil {
+		return "", err
+	}
+
+	// TODO how to set these on all requests?
+	req.Header.Add("Authorization", "Bearer "+c.JWT)
+	req.Header.Set("User-Agent", c.UserAgent)
+
+	resp, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+
+	if resp.StatusCode != 200 {
+		return "", errors.New("could not download call log")
+	}
+
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+
+	return string(body), nil
+}
+
+// extractResources will try to extract information to the
+// given test run based on a "reference".
+//
+// Currently as "reference" a part of the forge URL is used.
+// This contains the organisation, test case and the sequence
+// id of the test run. Example: "foo/demo/test_runs/19"
+func extractResources(ref string) testRunResources {
+	segments := strings.Split(ref, "/")
+
+	if len(segments) == 4 && segments[2] == "test_runs" {
+		return testRunResources{
+			organisation: segments[0],
+			testCase:     segments[1],
+			sequenceID:   segments[3],
+		}
+	}
+
+	if len(segments) == 3 {
+		return testRunResources{
+			organisation: segments[0],
+			testCase:     segments[1],
+			sequenceID:   segments[2],
+		}
+	}
+
+	if len(segments) == 1 {
+		return testRunResources{
+			uid: segments[0],
+		}
+	}
+
+	return testRunResources{}
+}

--- a/cmd/calllog.go
+++ b/cmd/calllog.go
@@ -1,0 +1,45 @@
+package cmd
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/spf13/cobra"
+)
+
+// calllogCmd represents the calllog command
+var calllogCmd = &cobra.Command{
+	Use:   "clog <test-run-ref>",
+	Short: "Fetch up to 10k lines of the test runs call log",
+	Long: `Will fetch up to 10k lines of the test runs call log.
+
+The call log contains:
+  * time (epoch in seconds)
+  * HTTP verb
+  * HTTP host
+  * request path
+  * HTTP Status Code
+  * response size (in Bytes)
+  * duration (in ms)
+  * request tag`,
+	Run: run,
+}
+
+func init() {
+	TestRunCmd.AddCommand(calllogCmd)
+}
+
+func run(cmd *cobra.Command, args []string) {
+	if len(args) != 1 {
+		log.Fatal("Expect exactly one argument: Test Run Reference")
+	}
+
+	client := NewClient()
+
+	result, err := client.TestRunCallLogPreview(args[0])
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Print(result)
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -52,7 +52,7 @@ func Execute() {
 
 // NewClient initializes a new API Client
 func NewClient() *api.Client {
-	return api.NewClient(rootOpts.APIEndpoint, viper.GetString("jwt"))
+	return api.NewClient(viper.GetString("endpoint"), viper.GetString("jwt"))
 }
 
 /*
@@ -64,16 +64,18 @@ func NewClient() *api.Client {
 func setupConfig() {
 	viper.SetEnvPrefix(EnvPrefix)
 	viper.BindEnv("jwt")
+	viper.BindEnv("endpoint")
 
 	viper.SetConfigName(ConfigFilename)
 	viper.AddConfigPath("$HOME")
 	viper.AddConfigPath(".")
 	viper.ReadInConfig()
 
-	viper.BindPFlag("jwt", RootCmd.Flags().Lookup("jwt"))
+	viper.BindPFlag("jwt", RootCmd.PersistentFlags().Lookup("jwt"))
+	viper.BindPFlag("endpoint", RootCmd.PersistentFlags().Lookup("endpoint"))
 }
 
 func init() {
 	RootCmd.PersistentFlags().StringVar(&rootOpts.APIEndpoint, "endpoint", "https://api.stormforger.com", "API Endpoint")
-	RootCmd.Flags().StringVar(&rootOpts.JWT, "jwt", "", "JWT access token")
+	RootCmd.PersistentFlags().StringVar(&rootOpts.JWT, "jwt", "", "JWT access token")
 }

--- a/cmd/test_run_logs.go
+++ b/cmd/test_run_logs.go
@@ -7,11 +7,12 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// calllogCmd represents the calllog command
-var calllogCmd = &cobra.Command{
-	Use:   "clog <test-run-ref>",
-	Short: "Fetch up to 10k lines of the test runs call log",
-	Long: `Will fetch up to 10k lines of the test runs call log.
+var (
+	// calllogCmd represents the calllog command
+	calllogCmd = &cobra.Command{
+		Use:   "logs <test-run-ref>",
+		Short: "Fetch up to 10k lines of the test runs call log",
+		Long: `Will fetch up to 10k lines of the test runs call log.
 
 The call log contains:
   * time (epoch in seconds)
@@ -22,16 +23,27 @@ The call log contains:
   * response size (in Bytes)
   * duration (in ms)
   * request tag`,
-	Run: run,
-}
+		Run: run,
+	}
+
+	logOpts struct {
+		Type string
+	}
+)
 
 func init() {
 	TestRunCmd.AddCommand(calllogCmd)
+
+	calllogCmd.Flags().StringVar(&logOpts.Type, "type", "request", "type of logs")
 }
 
 func run(cmd *cobra.Command, args []string) {
 	if len(args) != 1 {
 		log.Fatal("Expect exactly one argument: Test Run Reference")
+	}
+
+	if logOpts.Type != "request" {
+		log.Fatal(fmt.Sprintf("Unsupported log type %s", logOpts.Type))
 	}
 
 	client := NewClient()

--- a/cmd/testrun.go
+++ b/cmd/testrun.go
@@ -1,0 +1,21 @@
+package cmd
+
+import (
+	"log"
+
+	"github.com/spf13/cobra"
+)
+
+// TestRunCmd is the cobra definition
+var TestRunCmd = &cobra.Command{
+	Use:   "test-run",
+	Short: "Work with and manage test runs",
+	Long:  `Work with and manage test runs.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		log.Fatal("Cannot be run without subcommand!")
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(TestRunCmd)
+}


### PR DESCRIPTION
This PR adds the `test-run` command and it's (currently) only sub-command `logs`. It will fetch the request log up to the first 10k items. The log contains of:

* time (epoch in seconds)
* HTTP verb
* HTTP host
* request path
* HTTP Status Code
* response size (in Bytes)
* duration (in ms)
* request tag

separated by `;`.

## Usage

```
forge test-run logs <test-run-ref>
```

`<test-run-ref>` is in the form of:

* `$organisation/$test-case/$test-run-id` like `stormforger/demo/42`, or
* `$organisation/$test-case/test_runs/$test-run-id` like `stormforger/demo/test_runs/42`

`<test-run-ref>` can also be the test run uid (not supported by the API yet).

Using `--full` you will get the entire request/call log.

Using `--output=requests.log` you can save the output directly to file, instead of printing it to standard output.

Example:

```
$ forge test-run logs stormforger/demo/42
1477552519.730834;get;api.example.com;/;302;907;307.542;root
1477552519.733877;get;api.example.com;/en;200;4207;900.587;root-en
…
```