### PR TITLE
Test Base Management

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,6 @@ sudo: false
 language: go
 go:
 - '1.9.1'
-- master
-matrix:
-  allow_failures:
-    - go: master
 script: make test
 env:
   # GITHUB_TOKEN: tisba/"stormforger/cli goreleaser"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ language: go
 go:
 - '1.9.1'
 - master
+matrix:
+  allow_failures:
+    - go: master
 script: make test
 env:
   # GITHUB_TOKEN: tisba/"stormforger/cli goreleaser"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,8 @@
 sudo: false
 language: go
 go:
-- '1.8.3'
+- '1.9.1'
 - master
-install:
-- go get github.com/laher/goxc
 script: make test
 env:
   # GITHUB_TOKEN: tisba/"stormforger/cli goreleaser"

--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,7 @@ test: vet
 	script/gorun go test -v
 
 build:
-	go build \
-		-o ${BINARY}
+	go build -o ${BINARY}
 
 release:
 	goreleaser

--- a/api/client.go
+++ b/api/client.go
@@ -133,7 +133,7 @@ func createFormFile(w *multipart.Writer, fieldname string, filename string, cont
 	return w.CreatePart(h)
 }
 
-func newfileUploadRequest(uri string, params map[string]string, paramName string, fileName string, mimeType string, data io.Reader) (*http.Request, error) {
+func fileUploadRequest(uri string, method string, params map[string]string, paramName string, fileName string, mimeType string, data io.Reader) (*http.Request, error) {
 	body := &bytes.Buffer{}
 	writer := multipart.NewWriter(body)
 	part, err := createFormFile(writer, paramName, fileName, mimeType)
@@ -151,7 +151,7 @@ func newfileUploadRequest(uri string, params map[string]string, paramName string
 		return nil, err
 	}
 
-	req, err := http.NewRequest("POST", uri, body)
+	req, err := http.NewRequest(method, uri, body)
 	req.Header.Set("Content-Type", writer.FormDataContentType())
 	return req, err
 }

--- a/api/file_fixture.go
+++ b/api/file_fixture.go
@@ -82,7 +82,7 @@ func (c *Client) PushFileFixture(fileName string, data io.Reader, organization s
 		extraParams["file_fixture[file_fixture_version][field_names]"] = params.FieldNames
 	}
 
-	req, err := newfileUploadRequest(c.APIEndpoint+"/file_fixtures/"+organization, extraParams, "file_fixture[file_fixture_version][original]", fileName, "application/octet-stream", data)
+	req, err := fileUploadRequest(c.APIEndpoint+"/file_fixtures/"+organization, "POST", extraParams, "file_fixture[file_fixture_version][original]", fileName, "application/octet-stream", data)
 	if err != nil {
 		return "", err
 	}

--- a/api/har.go
+++ b/api/har.go
@@ -14,7 +14,7 @@ func (c *Client) Har(fileName string, data io.Reader) (string, error) {
 	//      finally: add options here
 	extraParams := map[string]string{}
 
-	req, err := newfileUploadRequest(c.APIEndpoint+"/har", extraParams, "har_file", fileName, "application/json", data)
+	req, err := fileUploadRequest(c.APIEndpoint+"/har", "POST", extraParams, "har_file", fileName, "application/json", data)
 
 	resp, err := c.HTTPClient.Do(req)
 	if err != nil {

--- a/api/testcase.go
+++ b/api/testcase.go
@@ -3,15 +3,52 @@ package api
 import (
 	"io"
 	"io/ioutil"
+	"net/http"
 )
+
+// ListTestCases returns a list of test cases
+func (c *Client) ListTestCases(organization string) ([]byte, error) {
+	path := "/test_cases?organisation_uid=" + organization
+
+	req, err := http.NewRequest("GET", c.APIEndpoint+path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	body, err := c.doRequest(req)
+	if err != nil {
+		return nil, err
+	}
+
+	return body, nil
+}
+
+// CheckExistanceTestCase returns a list of test cases
+func (c *Client) CheckExistanceTestCase(organization string, testCaseName string) ([]byte, error) {
+	path := "/test_cases/" + testCaseName + "?organisation_uid=" + organization
+
+	req, err := http.NewRequest("GET", c.APIEndpoint+path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	body, err := c.doRequest(req)
+	if err != nil {
+		return nil, err
+	}
+
+	return body, nil
+}
 
 // TestCaseValidate will send a test case definition (JS) to the API
 // to validate.
-func (c *Client) TestCaseValidate(fileName string, data io.Reader) (bool, string, error) {
+func (c *Client) TestCaseValidate(organization string, fileName string, data io.Reader) (bool, string, error) {
 	// TODO how to pass options here?
 	//      defining a struct maybe, but where?
 	//      finally: add options here
-	extraParams := map[string]string{}
+	extraParams := map[string]string{
+		"organisation_uid": organization,
+	}
 
 	req, err := fileUploadRequest(c.APIEndpoint+"/test_cases/validate", "POST", extraParams, "test_case[javascript_definition]", fileName, "application/javascript", data)
 	if err != nil {
@@ -35,4 +72,65 @@ func (c *Client) TestCaseValidate(fileName string, data io.Reader) (bool, string
 	}
 
 	return true, string(body), nil
+}
+
+// TestCaseCreate will send a test case definition (JS) to the API
+// to create it.
+func (c *Client) TestCaseCreate(organization string, testCaseName string, fileName string, data io.Reader) (bool, string, error) {
+	// TODO how to pass options here?
+	//      defining a struct maybe, but where?
+	//      finally: add options here
+	extraParams := map[string]string{
+		"test_case[name]":  testCaseName,
+		"organisation_uid": organization,
+	}
+
+	req, err := fileUploadRequest(c.APIEndpoint+"/test_cases", "POST", extraParams, "test_case[javascript_definition]", fileName, "application/javascript", data)
+	if err != nil {
+		return false, "", err
+	}
+
+	response, err := c.doRequestRaw(req)
+	if err != nil {
+		return false, "", err
+	}
+
+	body, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		return false, "", err
+	}
+
+	defer response.Body.Close()
+
+	return false, string(body), nil
+}
+
+// TestCaseUpdate will send a test case definition (JS) to the API
+// to update an existing test case it.
+func (c *Client) TestCaseUpdate(organization string, testCaseUid string, fileName string, data io.Reader) (bool, string, error) {
+	// TODO how to pass options here?
+	//      defining a struct maybe, but where?
+	//      finally: add options here
+	extraParams := map[string]string{
+		"organisation_uid": organization,
+	}
+
+	req, err := fileUploadRequest(c.APIEndpoint+"/test_cases/"+testCaseUid, "PATCH", extraParams, "test_case[javascript_definition]", fileName, "application/javascript", data)
+	if err != nil {
+		return false, "", err
+	}
+
+	response, err := c.doRequestRaw(req)
+	if err != nil {
+		return false, "", err
+	}
+
+	body, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		return false, "", err
+	}
+
+	defer response.Body.Close()
+
+	return false, string(body), nil
 }

--- a/api/testcase.go
+++ b/api/testcase.go
@@ -13,7 +13,7 @@ func (c *Client) TestCaseValidate(fileName string, data io.Reader) (bool, string
 	//      finally: add options here
 	extraParams := map[string]string{}
 
-	req, err := newfileUploadRequest(c.APIEndpoint+"/test_cases/validate", extraParams, "test_case", fileName, "application/javascript", data)
+	req, err := fileUploadRequest(c.APIEndpoint+"/test_cases/validate", "POST", extraParams, "test_case[javascript_definition]", fileName, "application/javascript", data)
 	if err != nil {
 		return false, "", err
 	}

--- a/api/testcase/main.go
+++ b/api/testcase/main.go
@@ -1,0 +1,13 @@
+package testcase
+
+// List is a list of TestCases, used for index action
+type List struct {
+	TestCases []*TestCase
+}
+
+// TestCase represents a single TestCase
+type TestCase struct {
+	ID          string `jsonapi:"primary,test_cases"`
+	Name        string `jsonapi:"attr,name"`
+	Description string `jsonapi:"attr,description"`
+}

--- a/api/testcase/main.go
+++ b/api/testcase/main.go
@@ -1,5 +1,14 @@
 package testcase
 
+import (
+	"fmt"
+	"io"
+	"log"
+	"reflect"
+
+	"github.com/google/jsonapi"
+)
+
 // List is a list of TestCases, used for index action
 type List struct {
 	TestCases []*TestCase
@@ -10,4 +19,19 @@ type TestCase struct {
 	ID          string `jsonapi:"primary,test_cases"`
 	Name        string `jsonapi:"attr,name"`
 	Description string `jsonapi:"attr,description"`
+}
+
+// ShowNames displays the name and uid of organisations
+func ShowNames(input io.Reader) {
+	items, err := jsonapi.UnmarshalManyPayload(input, reflect.TypeOf(new(TestCase)))
+
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	for _, item := range items {
+		testCase, _ := item.(*TestCase)
+
+		fmt.Printf("* %s (ID: %s)\n", testCase.Name, testCase.ID)
+	}
 }

--- a/cmd/datasource.go
+++ b/cmd/datasource.go
@@ -18,7 +18,11 @@ var (
 			log.Fatal("Cannot be run without subcommand, like validate!")
 		},
 
-		PersistentPreRun: ensureOrganisation,
+		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			if datasourceOpts.Organisation == "" {
+				log.Fatal("Missing organization flag")
+			}
+		},
 	}
 
 	datasourceOpts struct {
@@ -30,10 +34,4 @@ func init() {
 	RootCmd.AddCommand(datasourceCmd)
 
 	datasourceCmd.PersistentFlags().StringVarP(&datasourceOpts.Organisation, "organization", "o", "", "Name of the organization")
-}
-
-func ensureOrganisation(cmd *cobra.Command, args []string) {
-	if datasourceOpts.Organisation == "" {
-		log.Fatal("Missing organization flag")
-	}
 }

--- a/cmd/organisation.go
+++ b/cmd/organisation.go
@@ -9,7 +9,7 @@ import (
 var (
 	organisationCmd = &cobra.Command{
 		Use:     "organisation",
-		Aliases: []string{},
+		Aliases: []string{"o", "orga", "organization"},
 		Short:   "Manage organisations",
 		Run: func(cmd *cobra.Command, args []string) {
 			log.Fatal("Cannot be run without subcommand, like list!")

--- a/cmd/testcase.go
+++ b/cmd/testcase.go
@@ -9,7 +9,7 @@ import (
 // TestCaseCmd is the cobra definition
 var TestCaseCmd = &cobra.Command{
 	Use:     "test-case",
-	Aliases: []string{"tc"},
+	Aliases: []string{"testcase", "tc"},
 	Short:   "Work with and manage test cases",
 	Long:    `Work with and manage test cases.`,
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/testcase_create.go
+++ b/cmd/testcase_create.go
@@ -1,0 +1,77 @@
+package cmd
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	// testCaseCreateCmd represents the testCaseValidate command
+	testCaseCreateCmd = &cobra.Command{
+		Use:   "create",
+		Short: "Create a new test case",
+		Long:  `Create a new test case.`,
+		Run:   runTestCaseCreate,
+		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			if testCaseCreateOpts.Organisation == "" {
+				log.Fatal("Missing organization flag")
+			}
+		},
+	}
+
+	testCaseCreateOpts struct {
+		Organisation string
+		Name         string
+	}
+)
+
+func init() {
+	TestCaseCmd.AddCommand(testCaseCreateCmd)
+
+	testCaseCreateCmd.PersistentFlags().StringVarP(&testCaseCreateOpts.Organisation, "organization", "o", "", "Name of the organization")
+	testCaseCreateCmd.PersistentFlags().StringVarP(&testCaseCreateOpts.Name, "name", "n", "", "Name of the new test case")
+}
+
+func runTestCaseCreate(cmd *cobra.Command, args []string) {
+	if len(args) > 0 {
+		fileName, testCaseFile, err := readFromStdinOrReadFirstArgument(args, "test_case.js")
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		var testCaseName string
+		if testCaseCreateOpts.Name != "" {
+			testCaseName = testCaseCreateOpts.Name
+		} else if args[0] != "-" {
+			basename := filepath.Base(args[0])
+			testCaseName = strings.TrimSuffix(basename, filepath.Ext(basename))
+		} else {
+			log.Fatal("Name of test case missing")
+			fmt.Println()
+			os.Exit(1)
+		}
+
+		client := NewClient()
+
+		success, message, errValidation := client.TestCaseCreate(testCaseCreateOpts.Organisation, testCaseName, fileName, testCaseFile)
+		if errValidation != nil {
+			log.Fatal(errValidation)
+		}
+
+		if success {
+			os.Exit(0)
+		}
+
+		printPrettyJson(message)
+
+		fmt.Println()
+		os.Exit(1)
+	} else {
+		log.Fatal("Missing argument; test case file or - to read from stdin")
+	}
+}

--- a/cmd/testcase_list.go
+++ b/cmd/testcase_list.go
@@ -1,0 +1,46 @@
+package cmd
+
+import (
+	"bytes"
+	"log"
+
+	"github.com/spf13/cobra"
+	"github.com/stormforger/cli/api/testcase"
+)
+
+var (
+	// testCaseListCmd represents the testCaseValidate command
+	testCaseListCmd = &cobra.Command{
+		Use:   "list",
+		Short: "List a new test case",
+		Long:  `List a new test case.`,
+		Run:   runTestCaseList,
+		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			if testCaseListOpts.Organisation == "" {
+				log.Fatal("Missing organization flag")
+			}
+		},
+	}
+
+	testCaseListOpts struct {
+		Organisation string
+		Name         string
+	}
+)
+
+func init() {
+	TestCaseCmd.AddCommand(testCaseListCmd)
+
+	testCaseListCmd.PersistentFlags().StringVarP(&testCaseListOpts.Organisation, "organization", "o", "", "Name of the organization")
+}
+
+func runTestCaseList(cmd *cobra.Command, args []string) {
+	client := NewClient()
+
+	result, err := client.ListTestCases(testCaseListOpts.Organisation)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	testcase.ShowNames(bytes.NewReader(result))
+}

--- a/cmd/testcase_update.go
+++ b/cmd/testcase_update.go
@@ -1,0 +1,66 @@
+package cmd
+
+import (
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	// testCaseUpdateCmd represents the testCaseValidate command
+	testCaseUpdateCmd = &cobra.Command{
+		Use:   "update",
+		Short: "Update a new test case",
+		Long:  `Update a new test case.`,
+		Run:   runTestCaseUpdate,
+		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			if testCaseUpdateOpts.Organisation == "" {
+				log.Fatal("Missing organization flag")
+			}
+			if testCaseUpdateOpts.Uid == "" {
+				log.Fatal("Missing test case UID flag")
+			}
+		},
+	}
+
+	testCaseUpdateOpts struct {
+		Organisation string
+		Uid          string
+	}
+)
+
+func init() {
+	TestCaseCmd.AddCommand(testCaseUpdateCmd)
+
+	testCaseUpdateCmd.PersistentFlags().StringVarP(&testCaseUpdateOpts.Organisation, "organization", "o", "", "Name of the organization")
+	testCaseUpdateCmd.PersistentFlags().StringVarP(&testCaseUpdateOpts.Uid, "uid", "u", "", "UID of the test case")
+}
+
+func runTestCaseUpdate(cmd *cobra.Command, args []string) {
+	if len(args) > 0 {
+		fileName, testCaseFile, err := readFromStdinOrReadFirstArgument(args, "test_case.js")
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		client := NewClient()
+
+		success, message, err := client.TestCaseUpdate(testCaseUpdateOpts.Organisation, testCaseUpdateOpts.Uid, fileName, testCaseFile)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		if success {
+			os.Exit(0)
+		}
+
+		printPrettyJson(message)
+
+		fmt.Println()
+		os.Exit(1)
+	} else {
+		log.Fatal("Missing argument; test case file or - to read from stdin")
+	}
+}

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -1,7 +1,10 @@
 package cmd
 
 import (
+	"bytes"
+	"encoding/json"
 	"io"
+	"log"
 	"os"
 	"path/filepath"
 )
@@ -20,4 +23,22 @@ func readFromStdinOrReadFirstArgument(args []string, defaultFileName string) (fi
 	}
 
 	return fileName, reader, err
+}
+
+func printPrettyJson(message string) {
+	prettyJson := prettyFormatJson(message)
+
+	_, err := prettyJson.WriteTo(os.Stdout)
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+
+func prettyFormatJson(message string) (out bytes.Buffer) {
+	err := json.Indent(&out, []byte(message), "", "  ")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	return out
 }

--- a/testdata/cases/invalid.js
+++ b/testdata/cases/invalid.js
@@ -1,94 +1,10 @@
-definition.setTarget("testapp.loadtest.party");
+definition.setTarget();
 
 definition.setArrivalPhases([
   { duration: 5 * 60, rate: 50, max_users: 2000 },
-  { duration: 15 * 60, rate: 60, max_users: 5000 ,
+  { duration: 15 * 60, rate: 60, max_users: 5000 },
 ]);
 
-definition.setDataSources({
-  user: {
-    type: "file",
-    source: "authentication/users.csv",
-    fields: ["id", "email", "password"],
-  },
-  product: {
-    type: "file",
-    source: "products/base.csv",
-    fields: ["id"],
-  },
-  likeProbability: {
-    type: "random_number",
-    range: [1, 100],
-  },
-});
-
-definition.session("base", function(session) {
-  var user = session.pick("user");
-
-  session.post("/users/session", {
-    gzip: true,
-    tag: "login",
-    headers: {
-      "Accept": "application/json"
-    },
-    payload: JSON.stringify({
-      "email": user.email(),
-      "password": user.password()
-    }),
-    extraction: {
-      jsonpath: {
-        "authenticationToken": "user.auth_token",
-      }
-    },
-  });
-
-  session.get("/users/configuration", {
-    gzip: true,
-    tag: "user_configuration",
-    headers: {
-      "Accept": "application/json",
-      "X-DemoApp-Token": session.matchedValue("authenticationToken"),
-    },
-  });
-
-  session.wait(2, { random: true });
-
-  session.times(10, function(context) {
-    var productId = context.pick("product").id();
-
-    context.get("/products/details/" + productId, {
-      gzip: true,
-      tag: "product_details",
-      headers: {
-        "Accept": "application/json",
-        "X-DemoApp-Token": session.matchedValue("authenticationToken"),
-      },
-    });
-
-    // we are going to like a product 30% of the time
-    context.if(context.pick("likeProbability"), "lte", 30, function(context) {
-      context.wait(10, { random: true });
-
-      context.post("/products/like", {
-        gzip: true,
-        tag: "product_details",
-        headers: {
-          "Accept": "application/json",
-          "X-DemoApp-Token": context.matchedValue("authenticationToken"),
-        },
-        payload: JSON.stringify({
-          "product_id": productId
-        }),
-      });
-    });
-
-    context.wait(23, { random: true });
-  });
-});
-
-definition.session("other", function(session) {
-  session.forEver(function(context) {
-    context.get("/other");
-    context.wait(5);
-  });
+definition.session("invalid", function(session) {
+  session.get("/");
 });

--- a/testdata/cases/invalid_syntax.js
+++ b/testdata/cases/invalid_syntax.js
@@ -1,0 +1,10 @@
+definition.setTarget("testapp.loadtest.party");
+
+definition.setArrivalPhases([
+  { duration: 5 * 60, rate: 50, max_users: 2000 },
+  { duration: 15 * 60, rate: 60, max_users: 5000 ,
+]);
+
+definition.session("invalid-syntax", function(session) {
+  session.get("/");
+});

--- a/testdata/cases/valid.js
+++ b/testdata/cases/valid.js
@@ -5,43 +5,7 @@ definition.setArrivalPhases([
   { duration: 15 * 60, rate: 60, max_users: 5000 },
 ]);
 
-definition.setDataSources({
-  user: {
-    type: "file",
-    source: "authentication/users.csv",
-    fields: ["id", "email", "password"],
-  },
-  product: {
-    type: "file",
-    source: "products/base.csv",
-    fields: ["id"],
-  },
-  likeProbability: {
-    type: "random_number",
-    range: [1, 100],
-  },
-});
-
 definition.session("base", function(session) {
-  var user = session.pick("user");
-
-  session.post("/users/session", {
-    gzip: true,
-    tag: "login",
-    headers: {
-      "Accept": "application/json"
-    },
-    payload: JSON.stringify({
-      "email": user.email(),
-      "password": user.password()
-    }),
-    extraction: {
-      jsonpath: {
-        "authenticationToken": "user.auth_token",
-      }
-    },
-  });
-
   session.get("/users/configuration", {
     gzip: true,
     tag: "user_configuration",
@@ -52,43 +16,4 @@ definition.session("base", function(session) {
   });
 
   session.wait(2, { random: true });
-
-  session.times(10, function(context) {
-    var productId = context.pick("product").id();
-
-    context.get("/products/details/" + productId, {
-      gzip: true,
-      tag: "product_details",
-      headers: {
-        "Accept": "application/json",
-        "X-DemoApp-Token": session.matchedValue("authenticationToken"),
-      },
-    });
-
-    // we are going to like a product 30% of the time
-    context.if(context.pick("likeProbability"), "lte", 30, function(context) {
-      context.wait(10, { random: true });
-
-      context.post("/products/like", {
-        gzip: true,
-        tag: "product_details",
-        headers: {
-          "Accept": "application/json",
-          "X-DemoApp-Token": context.matchedValue("authenticationToken"),
-        },
-        payload: JSON.stringify({
-          "product_id": productId
-        }),
-      });
-    });
-
-    context.wait(23, { random: true });
-  });
-});
-
-definition.session("other", function(session) {
-  session.forEver(function(context) {
-    context.get("/other");
-    context.wait(5);
-  });
 });

--- a/testdata/cases/valid_with_warnings.js
+++ b/testdata/cases/valid_with_warnings.js
@@ -1,0 +1,87 @@
+definition.setTarget("testapp.loadtest.party");
+
+definition.setArrivalPhases([
+  { duration: 5 * 60, rate: 50, max_users: 2000 },
+  { duration: 15 * 60, rate: 60, max_users: 5000 },
+]);
+
+definition.setDataSources({
+  user: {
+    type: "file",
+    source: "authentication/users.csv",
+    fields: ["id", "email", "password"],
+  },
+  product: {
+    type: "file",
+    source: "products/base.csv",
+    fields: ["id"],
+  },
+  likeProbability: {
+    type: "random_number",
+    range: [1, 100],
+  },
+});
+
+definition.session("base", function(session) {
+  var user = session.pick("user");
+
+  session.post("/users/session", {
+    gzip: true,
+    tag: "login",
+    headers: {
+      "Accept": "application/json"
+    },
+    payload: JSON.stringify({
+      "email": user.email(),
+      "password": user.password()
+    }),
+    extraction: {
+      jsonpath: {
+        "authenticationToken": "user.auth_token",
+      }
+    },
+  });
+
+  session.get("/users/configuration", {
+    gzip: true,
+    tag: "user_configuration",
+    headers: {
+      "Accept": "application/json",
+      "X-DemoApp-Token": session.matchedValue("authenticationToken"),
+    },
+  });
+
+  session.wait(2, { random: true });
+
+  session.times(10, function(context) {
+    var productId = context.pick("product").id();
+
+    context.get("/products/details/" + productId, {
+      gzip: true,
+      tag: "product_details",
+      headers: {
+        "Accept": "application/json",
+        "X-DemoApp-Token": session.matchedValue("authenticationToken"),
+      },
+    });
+
+    // we are going to like a product 30% of the time
+    context.if(context.pick("likeProbability"), "lte", 30, function(context) {
+      context.wait(10, { random: true });
+
+      context.post("/products/like", {
+        gzip: true,
+        tag: "product_details",
+        headers: {
+          "Accept": "application/json",
+          "X-DemoApp-Token": context.matchedValue("authenticationToken"),
+        },
+        payload: JSON.stringify({
+          "product_id": productId
+        }),
+      });
+    });
+
+    context.wait(23, { random: true });
+  });
+});


### PR DESCRIPTION
This PR includes mainly a beta™ version of our new/upcoming test case management API.

Now you can

* `list`,
* `validate`,
* `create` and
* `update`

test cases using the `forge` CLI.

## Usage

The test case related subcommand is: `test-case` (aliased as `testcase` and `tc`).

For all commands you need to provide the organisation UID. You can obtain this UIDs via:

```
forge organisation list
```

All new test case related commands require you to pass in a test case definition. All three subcommands accept:

* path to JavaScript definition
* test definition to be piped in via standard in


### List Test Cases of Organisation

```
forge test-case list -o $ORGANISATION_UID
```


### Create a new Test Case

```
forge test-case create --organization $ORGANISATION_UID --name auth-service-basic cases/authentication/basic.js
```

Test Case name can be given explicitly via `--name` or inferred from the base name of the provided file.

The following command will create the new test cases with the name `basic`:

```
forge test-case create --organization $ORGANISATION_UID cases/authentication/basic.js
```


### Update an existing Test Case

```
forge test-case update --organization $ORGANISATION_UID cases/authentication/basic.js
```

* Currently you can only update the test case definition and not the name, description or other data.


### Validate a Test Case Definition

```
forge test-case validate --organization $ORGANISATION_UID cases/debug.js
```

* no test case will be created, this is only a validation

## Other News

* I opted to bump us to Go 1.9.1
* little refactoring here and there
* removed go master builds from travis for now (not sure why, but they were failing)