### PR TITLE
Bug: Fail if no config found

### DIFF
--- a/cmd/login.go
+++ b/cmd/login.go
@@ -39,9 +39,9 @@ func runLogin(cmd *cobra.Command, args []string) {
 	if err != nil {
 		log.Fatal(err)
 	} else {
-		color.Green("Login successful! Here is your JWT access token:\n\n")
-		color.Green("  " + jwt)
-		color.Green("\n")
+		color.White("Login successful! Add the JWT token to a .stormforger.toml file like this:\n\n")
+		color.Green("  echo 'jwt = \"" + jwt + "\"' >> .stormforger.toml")
+		color.Green("\n\n")
 	}
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -81,10 +81,7 @@ func setupConfig() {
 	viper.AddConfigPath(".")
 	viper.AddConfigPath("$HOME")
 
-	err = viper.ReadInConfig()
-	if err != nil {
-		log.Fatal(err)
-	}
+	viper.ReadInConfig()
 
 	err = viper.BindPFlag("jwt", RootCmd.PersistentFlags().Lookup("jwt"))
 	if err != nil {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -47,7 +47,10 @@ func Execute() {
 	}
 
 	if viper.GetString("jwt") == "" {
-		color.Yellow("\nNo JWT token in config file, environment or via command line flag!\n")
+		color.Yellow(`No JWT token in config file, environment or via command line flag!
+
+Use forge login to obtain a new JWT token.
+`)
 	}
 }
 


### PR DESCRIPTION
This was not noticed for a while, but when there was no `.stormforger.toml` in the current directory or home directory, `forge` will fail complaining that no configuration could be found. This is bad for new users :)

While on it, I also improved the message after `forge login`.