### PR TITLE
Print help on missing subcommands

### DIFF
--- a/cmd/datasource.go
+++ b/cmd/datasource.go
@@ -14,9 +14,6 @@ var (
 		Long: `Work with and manage data sources.
 
   Currently only a rough validation is implemented.`,
-		Run: func(cmd *cobra.Command, args []string) {
-			log.Fatal("Cannot be run without subcommand, like validate!")
-		},
 
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
 			if datasourceOpts.Organisation == "" {

--- a/cmd/organisation.go
+++ b/cmd/organisation.go
@@ -1,19 +1,12 @@
 package cmd
 
-import (
-	"log"
-
-	"github.com/spf13/cobra"
-)
+import "github.com/spf13/cobra"
 
 var (
 	organisationCmd = &cobra.Command{
 		Use:     "organisation",
 		Aliases: []string{"o", "orga", "organization"},
 		Short:   "Manage organisations",
-		Run: func(cmd *cobra.Command, args []string) {
-			log.Fatal("Cannot be run without subcommand, like list!")
-		},
 	}
 )
 

--- a/cmd/testcase.go
+++ b/cmd/testcase.go
@@ -1,10 +1,6 @@
 package cmd
 
-import (
-	"log"
-
-	"github.com/spf13/cobra"
-)
+import "github.com/spf13/cobra"
 
 // TestCaseCmd is the cobra definition
 var TestCaseCmd = &cobra.Command{
@@ -12,9 +8,6 @@ var TestCaseCmd = &cobra.Command{
 	Aliases: []string{"testcase", "tc"},
 	Short:   "Work with and manage test cases",
 	Long:    `Work with and manage test cases.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		log.Fatal("Cannot be run without subcommand!")
-	},
 }
 
 func init() {

--- a/cmd/testrun.go
+++ b/cmd/testrun.go
@@ -1,10 +1,6 @@
 package cmd
 
-import (
-	"log"
-
-	"github.com/spf13/cobra"
-)
+import "github.com/spf13/cobra"
 
 // TestRunCmd is the cobra definition
 var TestRunCmd = &cobra.Command{
@@ -12,9 +8,6 @@ var TestRunCmd = &cobra.Command{
 	Aliases: []string{"testrun", "tr"},
 	Short:   "Work with and manage test runs",
 	Long:    `Work with and manage test runs.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		log.Fatal("Cannot be run without subcommand!")
-	},
 }
 
 func init() {

--- a/cmd/testrun_list.go
+++ b/cmd/testrun_list.go
@@ -10,8 +10,8 @@ var (
 	// testRunListCmd represents the calllog command
 	testRunListCmd = &cobra.Command{
 		Use:   "list <test-case-ref>",
-		Short: "bla",
-		Long:  `bla`,
+		Short: "List of completed test runs",
+		Long:  `List of completed test runs.`,
 		Run:   testRunList,
 	}
 )


### PR DESCRIPTION
Previously we failed with an error if a subcommand was missing.

Now we simply use corba's default and print the usage/help information.