### PR TITLE
Add Docker builds

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -11,6 +11,9 @@ brew:
   folder: Formula
   homepage: "https://stormforger.com"
   description: "The StormForger Command Line Client, called 'forge'"
+dockers:
+  - image: stormforger/cli
+    latest: true
 builds:
 - goos:
   - linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,15 @@
 sudo: false
 language: go
 go:
-- '1.9.1'
+- "1.9.1"
 script: make test
+services:
+  - docker
 env:
-  # GITHUB_TOKEN: tisba/"stormforger/cli goreleaser"
-  - secure: "G+n4gBmpZU2AW9NA1DqKpg9rDYKYOKK2UGmg7nVmyG/tmqfI51852s+rAgQ1VKAlIbl/Wha+Et9rO17J26XaUuttkVAILqTgJXWVuedFVmLPYlKhyFbAONOwJIhK/1XMtCT8oDIWvSVtOJ9noAkstq5woySNwJ4RSMpZ91MT+ZCHXXM0ebP0L5prvgIgGN/0X9khbSG8jR3lCB/wOtmRVpI5c766mPexX5+F/aSKGnOOyE55PoYmUVVe7qW0dYqvcnJmlz4cUZXTCf1qAJzwO+iAzHxyzI2P9sa1f/ESDNgSUOQZuLzCB43cRsFlynbMYrrCUNbV8CZwW6T40KEMmo0XAcnfLuxQjR0YAaSXh0MuTHqkcetFkmx97hJA+jcQI1dsZCudbE1jLLxSb6fWvBWC9MfaV/sod9EnVak85PNliTGG7KWlasW2OcZl1TE9cnXps8jxPiwrk1X1V0xwe6frC+XeV08Xh//kvpa8uhPLSaSgOssngagiARae79cA43sf1rZLVBraec/loWyl5JW9pXPWvVrcDf/SBCvX46n/Z+FGEmMlqPexR5EmUWZAS9bNHEREmkfKKZKyP/Q76QnKhcPI45trRTkc1LfbyzKr7/HekJQFTzgi5uzU3Hbb6mUADHO7oekdU50b8RPo/2NSg2dkgVcDeGK9kapCeik="
+  # DOCKER_USERNAME="stormforger"
+  # DOCKER_PASSWORD=$geheim
+  # GITHUB_TOKEN=${see tisba/"stormforger/cli goreleaser"}
+  - secure: "gEoD3DDjgjUghN2biVOqXmygXZzmPB1jC6xR38y2OWAZhFqD+wScs73Y1Uz8fx7qWIa/pWKwH76MUcSwV6DPit1tOsRqi+/Kr8j984wOhoo70dwOPsrCH5w/HqluclHsOGRPOWaNiVPPjFC18YJvzVSWLfoi2bbMeXljgjDP5nVCfhZ/cc1+yGkwqVI3/c92clAFPFA4ZYc+2HQVyqvNbIR+iEOgIiV5u3wK/JgSvmWEKHdGKQIGKYAv9KkwB7ob2q4KiuyWukRN+l1c5OBSZadqYy2wwJKj/mzRRuV40G//kYK8Y3LMp6xXIhN+GHTCdUXlrl6CVUSD9s6o6TwGoQplJKzAHR6xkvqhDDQGV6DDA1lnEBeflsNZn6mfQ8ODdpzqZgUyiUTsuRnVPo3bHvgrws50wLP7q0MlDZj2Lz4+Et41135979+Ca1h7YDfs3Gr0CuNjZvtPEcVCPBuvjuI5SAedvzoRjhB66tcPTT+bw8JzuGd6lW0aR2FHbH/PreaWwFejlEoo7o8jvR4uOGirHWjfrpn4tDCl+E/aWhevsNEG73bF890ah76yZ0GGiQ8LTcMLyNrEgnQfE2+WZ/d4OBhDCEPhhQXcF3Oa18iOmq8Cag+AcG3rMCvtXD54j1apwaAIyyB1xDQwK1oJ4arJNb0W+/DORpVF1QhVKQ0="
 after_success:
+  - test -n "$TRAVIS_TAG" && docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
   - test -n "$TRAVIS_TAG" && curl -sL https://git.io/goreleaser | bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,3 @@
+FROM scratch
+COPY forge /
+ENTRYPOINT ["/forge"]


### PR DESCRIPTION
This PR adds a first, minimal docker build, which will make docker images of the CLI available under [`stormforger/cli`](https://hub.docker.com/r/stormforger/cli/).

The used `Dockerfile` is very minimalistic and only contains the binary currently.