### PR TITLE
Add --watch to test-case launch command

### DIFF
--- a/cmd/testrun_watch.go
+++ b/cmd/testrun_watch.go
@@ -1,11 +1,6 @@
 package cmd
 
 import (
-	"fmt"
-	"log"
-	"os"
-	"time"
-
 	"github.com/spf13/cobra"
 	"github.com/stormforger/cli/api"
 )
@@ -48,34 +43,7 @@ func init() {
 }
 
 func testRunWatch(cmd *cobra.Command, args []string) {
-	client := NewClient()
-
-	started := time.Now()
-
-	for true {
-		runningSince := time.Now().Sub(started).Seconds()
-
-		testRun, response, err := client.TestRunWatch(args[0])
-		if err != nil {
-			log.Fatal(err)
-		}
-
-		fmt.Println(response)
-
-		if !testRunOkay(&testRun) {
-			os.Exit(1)
-		}
-
-		if testRunSuccess(&testRun) {
-			os.Exit(0)
-		}
-
-		if testRunWatchOpts.MaxWatchTime > 0 && int(runningSince) > testRunWatchOpts.MaxWatchTime {
-			os.Exit(2)
-		}
-
-		time.Sleep(5 * time.Second)
-	}
+	watchTestRun(args[0], testRunWatchOpts.MaxWatchTime)
 }
 
 func testRunOkay(testRun *api.TestRun) bool {

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -3,12 +3,14 @@ package cmd
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 )
 
 func readFromStdinOrReadFirstArgument(args []string, defaultFileName string) (fileName string, reader io.Reader, err error) {
@@ -52,4 +54,35 @@ func readOrganisationUIDFromFile() string {
 	}
 
 	return strings.TrimSpace(string(content))
+}
+
+func watchTestRun(testRunUID string, maxWatchTime int) {
+	client := NewClient()
+
+	started := time.Now()
+
+	for true {
+		runningSince := time.Now().Sub(started).Seconds()
+
+		testRun, response, err := client.TestRunWatch(testRunUID)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		fmt.Println(response)
+
+		if !testRunOkay(&testRun) {
+			os.Exit(1)
+		}
+
+		if testRunSuccess(&testRun) {
+			os.Exit(0)
+		}
+
+		if maxWatchTime > 0 && int(runningSince) > maxWatchTime {
+			os.Exit(2)
+		}
+
+		time.Sleep(5 * time.Second)
+	}
 }


### PR DESCRIPTION
For CI integration it is useful to launch a test and watch it right away.

With this PR you can now do:

```
forge test-case launch xPSX5KXm --watch
```

which will trigger the test case to be launched and watch it until completion. Like with `forge test-run watch $TEST_RUN_UID` you can also specify a watch timeout.

See `--help` for more information.