### PR TITLE
Improve Organisation/UID Handling

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -22,7 +22,7 @@ builds:
   goarch:
   - amd64
   main: .
-  ldflags: -linkmode external -extldflags "-static" -s -w -X github.com/stormforger/cli/buildinfo.version={{.Version}} -X github.com/stormforger/cli/buildinfo.commit={{.Commit}} -X github.com/stormforger/cli/buildinfo.date={{.Date}}
+  ldflags: -s -w -X github.com/stormforger/cli/buildinfo.version={{.Version}} -X github.com/stormforger/cli/buildinfo.commit={{.Commit}} -X github.com/stormforger/cli/buildinfo.date={{.Date}}
   binary: forge
 archive:
   format: zip

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM golang:alpine
+FROM ubuntu:trusty
 
 COPY forge /bin
 
-RUN apk --update add ca-certificates
+RUN apt-get -y update && apt-get -y install ca-certificates
 
-ENTRYPOINT ["/bin/forge"]
+ENTRYPOINT [ "forge" ]

--- a/api/testcase.go
+++ b/api/testcase.go
@@ -98,13 +98,11 @@ func (c *Client) TestCaseCreate(organization string, testCaseName string, fileNa
 
 // TestCaseUpdate will send a test case definition (JS) to the API
 // to update an existing test case it.
-func (c *Client) TestCaseUpdate(organization string, testCaseUID string, fileName string, data io.Reader) (bool, string, error) {
+func (c *Client) TestCaseUpdate(testCaseUID string, fileName string, data io.Reader) (bool, string, error) {
 	// TODO how to pass options here?
 	//      defining a struct maybe, but where?
 	//      finally: add options here
-	extraParams := map[string]string{
-		"organisation_uid": organization,
-	}
+	extraParams := map[string]string{}
 
 	req, err := fileUploadRequest(c.APIEndpoint+"/test_cases/"+testCaseUID, "PATCH", extraParams, "test_case[javascript_definition]", fileName, "application/javascript", data)
 	if err != nil {

--- a/cmd/datasource.go
+++ b/cmd/datasource.go
@@ -16,11 +16,10 @@ var (
   Currently only a rough validation is implemented.`,
 
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			datasourceOpts.Organisation = findFirstNonEmpty([]string{datasourceOpts.Organisation, readOrganisationUIDFromFile(), rootOpts.DefaultOrganisation})
+
 			if datasourceOpts.Organisation == "" {
-				datasourceOpts.Organisation = readOrganisationUIDFromFile()
-				if datasourceOpts.Organisation == "" {
-					log.Fatal("Missing organization flag")
-				}
+				log.Fatal("Missing organization")
 			}
 		},
 	}

--- a/cmd/organisation_list.go
+++ b/cmd/organisation_list.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	"fmt"
 	"log"
 
 	"github.com/spf13/cobra"
@@ -12,13 +13,19 @@ var (
 	organisationListCmd = &cobra.Command{
 		Use:     "list",
 		Aliases: []string{},
-		Short:   "Manage organisations",
+		Short:   "List organisations you have access to",
 		Run:     runOrganisationList,
+	}
+
+	organisationListOpts struct {
+		JSON bool
 	}
 )
 
 func init() {
 	organisationCmd.AddCommand(organisationListCmd)
+
+	organisationListCmd.Flags().BoolVarP(&organisationListOpts.JSON, "json", "", false, "Output machine-readable JSON")
 }
 
 func runOrganisationList(cmd *cobra.Command, args []string) {
@@ -29,5 +36,9 @@ func runOrganisationList(cmd *cobra.Command, args []string) {
 		log.Fatal(err)
 	}
 
-	organisation.ShowNames(bytes.NewReader(result))
+	if organisationListOpts.JSON {
+		fmt.Println(string(result))
+	} else {
+		organisation.ShowNames(bytes.NewReader(result))
+	}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -25,8 +25,9 @@ Happy Load Testing :)`,
 	}
 
 	rootOpts struct {
-		APIEndpoint string
-		JWT         string
+		APIEndpoint         string
+		JWT                 string
+		DefaultOrganisation string
 	}
 )
 
@@ -95,9 +96,17 @@ func setupConfig() {
 	if err != nil {
 		log.Fatal(err)
 	}
+
+	err = viper.BindPFlag("defaults.organisation", RootCmd.PersistentFlags().Lookup("default-organisation"))
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	rootOpts.DefaultOrganisation = viper.GetString("defaults.organisation")
 }
 
 func init() {
 	RootCmd.PersistentFlags().StringVar(&rootOpts.APIEndpoint, "endpoint", "https://api.stormforger.com", "API Endpoint")
 	RootCmd.PersistentFlags().StringVar(&rootOpts.JWT, "jwt", "", "JWT access token")
+	RootCmd.PersistentFlags().StringVar(&rootOpts.DefaultOrganisation, "default-organisation", "", "Default organisation UID to use")
 }

--- a/cmd/testcase_create.go
+++ b/cmd/testcase_create.go
@@ -18,11 +18,10 @@ var (
 		Long:  `Create a new test case.`,
 		Run:   runTestCaseCreate,
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			testCaseCreateOpts.Organisation = findFirstNonEmpty([]string{testCaseCreateOpts.Organisation, readOrganisationUIDFromFile(), rootOpts.DefaultOrganisation})
+
 			if testCaseCreateOpts.Organisation == "" {
-				testCaseCreateOpts.Organisation = readOrganisationUIDFromFile()
-				if testCaseCreateOpts.Organisation == "" {
-					log.Fatal("Missing organization flag")
-				}
+				log.Fatal("Missing organization")
 			}
 		},
 	}

--- a/cmd/testcase_list.go
+++ b/cmd/testcase_list.go
@@ -36,11 +36,14 @@ var (
 	testCaseListOpts struct {
 		Organisation string
 		Name         string
+		JSON         bool
 	}
 )
 
 func init() {
 	TestCaseCmd.AddCommand(testCaseListCmd)
+
+	testCaseListCmd.Flags().BoolVarP(&testCaseListOpts.JSON, "json", "", false, "Output machine-readable JSON")
 }
 
 func runTestCaseList(cmd *cobra.Command, args []string) {
@@ -52,6 +55,11 @@ func runTestCaseList(cmd *cobra.Command, args []string) {
 	}
 
 	if status {
+		if testCaseListOpts.JSON {
+			fmt.Println(string(result))
+			return
+		}
+
 		testcase.ShowNames(bytes.NewReader(result))
 	} else {
 		fmt.Fprintln(os.Stderr, "Could not list test cases!")

--- a/cmd/testcase_list.go
+++ b/cmd/testcase_list.go
@@ -14,21 +14,19 @@ var (
 	// testCaseListCmd represents the testCaseValidate command
 	testCaseListCmd = &cobra.Command{
 		Use:   "list",
-		Short: "List a new test case",
-		Long:  `List a new test case.`,
+		Short: "List test case for a given organization",
 		Run:   runTestCaseList,
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			candidates := []string{readOrganisationUIDFromFile(), rootOpts.DefaultOrganisation}
+
 			if len(args) >= 1 {
-				testCaseListOpts.Organisation = args[0]
-			} else {
-				testCaseListOpts.Organisation = ""
+				candidates = append([]string{args[0]}, candidates...)
 			}
 
+			testCaseListOpts.Organisation = findFirstNonEmpty(candidates)
+
 			if testCaseListOpts.Organisation == "" {
-				testCaseListOpts.Organisation = readOrganisationUIDFromFile()
-				if testCaseListOpts.Organisation == "" {
-					log.Fatal("Missing organization flag")
-				}
+				log.Fatal("Missing organization")
 			}
 		},
 	}

--- a/cmd/testcase_update.go
+++ b/cmd/testcase_update.go
@@ -12,17 +12,9 @@ var (
 	// testCaseUpdateCmd represents the testCaseValidate command
 	testCaseUpdateCmd = &cobra.Command{
 		Use:   "update",
-		Short: "Update a new test case",
-		Long:  `Update a new test case.`,
+		Short: "Update an existing test case",
 		Run:   runTestCaseUpdate,
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
-			if testCaseUpdateOpts.Organisation == "" {
-				testCaseUpdateOpts.Organisation = readOrganisationUIDFromFile()
-				if testCaseUpdateOpts.Organisation == "" {
-					log.Fatal("Missing organization flag")
-				}
-			}
-
 			if testCaseUpdateOpts.UID == "" {
 				log.Fatal("Missing test case UID flag")
 			}
@@ -30,8 +22,7 @@ var (
 	}
 
 	testCaseUpdateOpts struct {
-		Organisation string
-		UID          string
+		UID string
 	}
 )
 
@@ -50,7 +41,7 @@ func runTestCaseUpdate(cmd *cobra.Command, args []string) {
 
 		client := NewClient()
 
-		success, message, err := client.TestCaseUpdate(testCaseUpdateOpts.Organisation, testCaseUpdateOpts.UID, fileName, testCaseFile)
+		success, message, err := client.TestCaseUpdate(testCaseUpdateOpts.UID, fileName, testCaseFile)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/cmd/testcase_validate.go
+++ b/cmd/testcase_validate.go
@@ -16,11 +16,10 @@ var (
 		Long:  `Upload a test case definition JavaScript and validate it.`,
 		Run:   runTestCaseValidate,
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			testCaseValidateOpts.Organisation = findFirstNonEmpty([]string{testCaseValidateOpts.Organisation, readOrganisationUIDFromFile(), rootOpts.DefaultOrganisation})
+
 			if testCaseValidateOpts.Organisation == "" {
-				testCaseValidateOpts.Organisation = readOrganisationUIDFromFile()
-				if testCaseValidateOpts.Organisation == "" {
-					log.Fatal("Missing organization flag")
-				}
+				log.Fatal("Missing organization")
 			}
 		},
 	}

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -86,3 +86,13 @@ func watchTestRun(testRunUID string, maxWatchTime int) {
 		time.Sleep(5 * time.Second)
 	}
 }
+
+func findFirstNonEmpty(candidates []string) string {
+	for _, item := range candidates {
+		if item != "" {
+			return item
+		}
+	}
+
+	return ""
+}


### PR DESCRIPTION
* add `--json` for machine readable output on `organisation list` and `test-case list`
* add global `--default-organisation` flag and `defaults.organisation` TOML configuration to allow to define a fallback/default if no organisation UID is provided
* remove the requirement for organisation UID to be present when updating a test case