### PR TITLE
test-case commands: Allow non UID references

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,37 @@ organisation = "abcdef42"
 To get the UID to your organisation, run: `forge organisation list`.
 
 
+## Usage
+
+Help is available to all commands with `--help`.
+
+
+### Test Cases
+
+Test cases are scoped by organisation. You always have to provide at least the organisation (`acme-inc`) or a test case in form of `organisation-name/test-case-name`.
+
+You can...
+* list existing test cases in your `acme-inc` organisation: `forge test-case list acme-inc`
+* validate a test definition without saving it: `forge test-case validate acme-inc cases/simple.js`
+* create a new test case named `checkout` inside `acme-inc`: `forge test-case create acme-inc/checkout cases/simple.js`
+* update an existing test case named `checkout` inside `acme-inc`: `forge test-case update acme-inc/checkout cases/simple.js`
+
+Commands that take a file, also accept `-` to take input from stdin.
+
+
+### Test Runs
+
+Test runs are executions of test cases.
+
+You can...
+* launch `acme-inc/checkout`: `forge test-case launch acme-inc/checkout`
+* watch
+* list
+* show
+
+…
+
+
 ### Data Sources
 
 Data sources are scoped per organisation. Working with data sources can be done with the `datasource` (or short `ds`) sub command, e.g. `forge datasource ls`.

--- a/README.md
+++ b/README.md
@@ -96,7 +96,11 @@ You can...
 * create a new test case named `checkout` inside `acme-inc`: `forge test-case create acme-inc/checkout cases/simple.js`
 * update an existing test case named `checkout` inside `acme-inc`: `forge test-case update acme-inc/checkout cases/simple.js`
 
-Commands that take a file, also accept `-` to take input from stdin.
+Commands that take a file, also accept `-` to take input from stdin. Example:
+
+```
+sed 's/${target}/testapp.loadtest.party/g' tests/templated.js | forge tc update acme-inc/checkout -
+```
 
 
 ### Test Runs

--- a/api/organisation/main.go
+++ b/api/organisation/main.go
@@ -20,6 +20,27 @@ type Organisation struct {
 	Name string `jsonapi:"attr,name"`
 }
 
+// Unmarshal unmarshals a list of Organisations records
+func Unmarshal(input io.Reader) (List, error) {
+	items, err := jsonapi.UnmarshalManyPayload(input, reflect.TypeOf(new(Organisation)))
+	if err != nil {
+		return List{}, err
+	}
+
+	result := List{}
+
+	for _, item := range items {
+		fixture, ok := item.(*Organisation)
+		if !ok {
+			return List{}, fmt.Errorf("Type assertion failed")
+		}
+
+		result.Organisations = append(result.Organisations, fixture)
+	}
+
+	return result, nil
+}
+
 // ShowNames displays the name and uid of organisations
 func ShowNames(input io.Reader) {
 	items, err := jsonapi.UnmarshalManyPayload(input, reflect.TypeOf(new(Organisation)))
@@ -33,4 +54,23 @@ func ShowNames(input io.Reader) {
 
 		fmt.Printf("* %s (ID: %s)\n", organisation.Name, organisation.ID)
 	}
+}
+
+// FindByNameOrUID look up a Organisation by name in List
+func (organisations List) FindByNameOrUID(nameOrUID string) Organisation {
+	// first, try to find test by UID
+	for _, organisation := range organisations.Organisations {
+		if organisation.ID == nameOrUID {
+			return *organisation
+		}
+	}
+
+	// then, try to find by name
+	for _, organisation := range organisations.Organisations {
+		if organisation.Name == nameOrUID {
+			return *organisation
+		}
+	}
+
+	return Organisation{}
 }

--- a/api/testcase/main.go
+++ b/api/testcase/main.go
@@ -35,3 +35,43 @@ func ShowNames(input io.Reader) {
 		fmt.Printf("* %s (ID: %s)\n", testCase.Name, testCase.ID)
 	}
 }
+
+// Unmarshal unmarshals a list of TestCase records
+func Unmarshal(input io.Reader) (List, error) {
+	items, err := jsonapi.UnmarshalManyPayload(input, reflect.TypeOf(new(TestCase)))
+	if err != nil {
+		return List{}, err
+	}
+
+	result := List{}
+
+	for _, item := range items {
+		testcas, ok := item.(*TestCase)
+		if !ok {
+			return List{}, fmt.Errorf("Type assertion failed")
+		}
+
+		result.TestCases = append(result.TestCases, testcas)
+	}
+
+	return result, nil
+}
+
+// FindByNameOrUID look up a TestCase by name in List
+func (testcases List) FindByNameOrUID(nameOrUID string) TestCase {
+	// first, try to find test case by UID
+	for _, testCase := range testcases.TestCases {
+		if testCase.ID == nameOrUID {
+			return *testCase
+		}
+	}
+
+	// then, try to find case by name
+	for _, testCase := range testcases.TestCases {
+		if testCase.Name == nameOrUID {
+			return *testCase
+		}
+	}
+
+	return TestCase{}
+}

--- a/cmd/testcase_create.go
+++ b/cmd/testcase_create.go
@@ -37,7 +37,7 @@ Examples
 			}
 
 			if len(args) < 2 {
-				log.Fatal("Missing arguments; test case reference and test case file")
+				log.Fatal("Missing arguments; test case reference and test case file (or - to read from stdin)")
 			}
 
 			segments := strings.Split(args[0], "/")
@@ -73,40 +73,36 @@ func init() {
 func runTestCaseCreate(cmd *cobra.Command, args []string) {
 	organizationUID := testCaseCreateOpts.Organisation
 
-	if len(args) > 0 {
-		fileName, testCaseFile, err := readFromStdinOrReadFromArgument(args, "test_case.js", 1)
-		if err != nil {
-			log.Fatal(err)
-		}
+	fileName, testCaseFile, err := readFromStdinOrReadFromArgument(args, "test_case.js", 1)
+	if err != nil {
+		log.Fatal(err)
+	}
 
-		var testCaseName string
-		if testCaseCreateOpts.Name != "" {
-			testCaseName = testCaseCreateOpts.Name
-		} else if args[0] != "-" {
-			basename := filepath.Base(args[0])
-			testCaseName = strings.TrimSuffix(basename, filepath.Ext(basename))
-		} else {
-			log.Fatal("Name of test case missing")
-			fmt.Println()
-			os.Exit(1)
-		}
-
-		client := NewClient()
-
-		success, message, errValidation := client.TestCaseCreate(organizationUID, testCaseName, fileName, testCaseFile)
-		if errValidation != nil {
-			log.Fatal(errValidation)
-		}
-
-		if success {
-			os.Exit(0)
-		}
-
-		printPrettyJSON(message)
-
+	var testCaseName string
+	if testCaseCreateOpts.Name != "" {
+		testCaseName = testCaseCreateOpts.Name
+	} else if args[0] != "-" {
+		basename := filepath.Base(args[0])
+		testCaseName = strings.TrimSuffix(basename, filepath.Ext(basename))
+	} else {
+		log.Fatal("Name of test case missing")
 		fmt.Println()
 		os.Exit(1)
-	} else {
-		log.Fatal("Missing argument; test case file or - to read from stdin")
 	}
+
+	client := NewClient()
+
+	success, message, errValidation := client.TestCaseCreate(organizationUID, testCaseName, fileName, testCaseFile)
+	if errValidation != nil {
+		log.Fatal(errValidation)
+	}
+
+	if success {
+		os.Exit(0)
+	}
+
+	printPrettyJSON(message)
+
+	fmt.Println()
+	os.Exit(1)
 }

--- a/cmd/testcase_create.go
+++ b/cmd/testcase_create.go
@@ -13,12 +13,11 @@ import (
 var (
 	// testCaseCreateCmd represents the testCaseValidate command
 	testCaseCreateCmd = &cobra.Command{
-		Use:   "create <organisation-ref|test-case-ref> <test-case-file>",
+		Use:   "create <test-case-ref> <test-case-file>",
 		Short: "Create a new test case",
 		Long: `Create a new test case.
 
-<test-case-ref> can be 'organisation/test-case'. <organisation-ref> is
-either 'organisation name' or the organisation's UID.
+<test-case-ref> is 'organisation-name/test-case-name'.
 
 Examples
 --------
@@ -43,13 +42,18 @@ Examples
 
 			segments := strings.Split(args[0], "/")
 
+			if len(segments) != 2 {
+				log.Fatal("Invalid argument: <test-case-ref> has to be like organisation-name/test-case-name")
+			}
+
 			testCaseCreateOpts.Organisation = lookupOrganisationUID(*NewClient(), segments[0])
 			if testCaseCreateOpts.Organisation == "" {
 				log.Fatal("Missing organization")
 			}
 
-			if len(segments) == 2 {
-				testCaseCreateOpts.Name = segments[1]
+			testCaseCreateOpts.Name = segments[1]
+			if testCaseCreateOpts.Name == "" {
+				log.Fatal("Missing test case name")
 			}
 		},
 	}

--- a/cmd/testcase_launch.go
+++ b/cmd/testcase_launch.go
@@ -16,8 +16,22 @@ var (
 	testRunLaunchCmd = &cobra.Command{
 		Use:   "launch <test-case-ref>",
 		Short: "Create and launch a new test run",
-		Long:  `Create and launch a new test run based on given test case`,
-		Run:   testRunLaunch,
+		Long: `Create and launch a new test run based on given test case
+
+<test-case-ref> can be 'organisation/test-case' or 'test-case-uid'.
+
+Examples
+--------
+* launch by organisation and test case name
+
+  forge test-case launch acme-inc/checkout
+
+* alternatively the test case UID can also be provided
+
+  forge test-case launch xPSX5KXM
+
+`,
+		Run: testRunLaunch,
 	}
 
 	testRunLaunchOpts struct {
@@ -40,7 +54,9 @@ func init() {
 func testRunLaunch(cmd *cobra.Command, args []string) {
 	client := NewClient()
 
-	status, response, err := client.TestRunCreate(args[0], testRunLaunchOpts.Title, testRunLaunchOpts.Notes)
+	testCaseUID := lookupTestCase(*client, args[0])
+
+	status, response, err := client.TestRunCreate(testCaseUID, testRunLaunchOpts.Title, testRunLaunchOpts.Notes)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/testcase_launch.go
+++ b/cmd/testcase_launch.go
@@ -18,7 +18,7 @@ var (
 		Short: "Create and launch a new test run",
 		Long: `Create and launch a new test run based on given test case
 
-<test-case-ref> can be 'organisation/test-case' or 'test-case-uid'.
+<test-case-ref> can be 'organisation-name/test-case-name' or 'test-case-uid'.
 
 Examples
 --------

--- a/cmd/testcase_list.go
+++ b/cmd/testcase_list.go
@@ -13,9 +13,10 @@ import (
 var (
 	// testCaseListCmd represents the testCaseValidate command
 	testCaseListCmd = &cobra.Command{
-		Use:   "list <organization-ref>",
-		Short: "List test case for a given organization",
-		Run:   runTestCaseList,
+		Use:     "list <organization-ref>",
+		Aliases: []string{"ls"},
+		Short:   "List test case for a given organization",
+		Run:     runTestCaseList,
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
 			if len(args) > 1 {
 				log.Fatal("Too many arguments")

--- a/cmd/testcase_list.go
+++ b/cmd/testcase_list.go
@@ -13,14 +13,21 @@ import (
 var (
 	// testCaseListCmd represents the testCaseValidate command
 	testCaseListCmd = &cobra.Command{
-		Use:   "list",
+		Use:   "list <organization-ref>",
 		Short: "List test case for a given organization",
 		Run:   runTestCaseList,
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
-			candidates := []string{readOrganisationUIDFromFile(), rootOpts.DefaultOrganisation}
+			if len(args) > 1 {
+				log.Fatal("Too many arguments")
+			}
+
+			candidates := []string{
+				readOrganisationUIDFromFile(),
+				rootOpts.DefaultOrganisation,
+			}
 
 			if len(args) >= 1 {
-				candidates = append([]string{args[0]}, candidates...)
+				candidates = append([]string{lookupOrganisationUID(*NewClient(), args[0])}, candidates...)
 			}
 
 			testCaseListOpts.Organisation = findFirstNonEmpty(candidates)
@@ -33,7 +40,6 @@ var (
 
 	testCaseListOpts struct {
 		Organisation string
-		Name         string
 		JSON         bool
 	}
 )

--- a/cmd/testcase_list.go
+++ b/cmd/testcase_list.go
@@ -21,17 +21,11 @@ var (
 				log.Fatal("Too many arguments")
 			}
 
-			candidates := []string{
-				readOrganisationUIDFromFile(),
-				rootOpts.DefaultOrganisation,
+			if len(args) < 1 {
+				log.Fatal("Missing organization")
 			}
 
-			if len(args) >= 1 {
-				candidates = append([]string{lookupOrganisationUID(*NewClient(), args[0])}, candidates...)
-			}
-
-			testCaseListOpts.Organisation = findFirstNonEmpty(candidates)
-
+			testCaseListOpts.Organisation = lookupOrganisationUID(*NewClient(), args[0])
 			if testCaseListOpts.Organisation == "" {
 				log.Fatal("Missing organization")
 			}

--- a/cmd/testcase_update.go
+++ b/cmd/testcase_update.go
@@ -11,37 +11,52 @@ import (
 var (
 	// testCaseUpdateCmd represents the testCaseValidate command
 	testCaseUpdateCmd = &cobra.Command{
-		Use:   "update",
+		Use:   "update <test-case-ref> <test-case-file>",
 		Short: "Update an existing test case",
-		Run:   runTestCaseUpdate,
+		Long: `Update an existing test case
+
+<test-case-ref> can be 'organisation/test-case' or 'test-case-uid'.
+
+Examples
+--------
+* update a test case by file
+
+  forge test-case update acme-inc/checkout cases/checkout_process.js
+
+* alternatively the test definition can be piped in as well
+
+  cat cases/checkout_process.js | forge test-case update acme-inc/checkout -
+
+`,
+		Run: runTestCaseUpdate,
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
-			if testCaseUpdateOpts.UID == "" {
-				log.Fatal("Missing test case UID flag")
+			if len(args) < 2 {
+				log.Fatal("Missing arguments; test case reference and test case file")
+			}
+
+			if len(args) > 2 {
+				log.Fatal("Too many arguments")
 			}
 		},
-	}
-
-	testCaseUpdateOpts struct {
-		UID string
 	}
 )
 
 func init() {
 	TestCaseCmd.AddCommand(testCaseUpdateCmd)
-
-	testCaseUpdateCmd.PersistentFlags().StringVarP(&testCaseUpdateOpts.UID, "uid", "u", "", "UID of the test case")
 }
 
 func runTestCaseUpdate(cmd *cobra.Command, args []string) {
-	if len(args) > 0 {
-		fileName, testCaseFile, err := readFromStdinOrReadFirstArgument(args, "test_case.js")
+	client := NewClient()
+
+	testCaseUID := lookupTestCase(*client, args[0])
+
+	if len(args) == 2 {
+		fileName, testCaseFile, err := readFromStdinOrReadFromArgument(args, "test_case.js", 1)
 		if err != nil {
 			log.Fatal(err)
 		}
 
-		client := NewClient()
-
-		success, message, err := client.TestCaseUpdate(testCaseUpdateOpts.UID, fileName, testCaseFile)
+		success, message, err := client.TestCaseUpdate(testCaseUID, fileName, testCaseFile)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/cmd/testcase_update.go
+++ b/cmd/testcase_update.go
@@ -31,7 +31,7 @@ Examples
 		Run: runTestCaseUpdate,
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
 			if len(args) < 2 {
-				log.Fatal("Missing arguments; test case reference and test case file")
+				log.Fatal("Missing arguments; test case reference and test case file (or - to read from stdin)")
 			}
 
 			if len(args) > 2 {
@@ -50,26 +50,22 @@ func runTestCaseUpdate(cmd *cobra.Command, args []string) {
 
 	testCaseUID := lookupTestCase(*client, args[0])
 
-	if len(args) == 2 {
-		fileName, testCaseFile, err := readFromStdinOrReadFromArgument(args, "test_case.js", 1)
-		if err != nil {
-			log.Fatal(err)
-		}
-
-		success, message, err := client.TestCaseUpdate(testCaseUID, fileName, testCaseFile)
-		if err != nil {
-			log.Fatal(err)
-		}
-
-		if success {
-			os.Exit(0)
-		}
-
-		printPrettyJSON(message)
-
-		fmt.Println()
-		os.Exit(1)
-	} else {
-		log.Fatal("Missing argument; test case file or - to read from stdin")
+	fileName, testCaseFile, err := readFromStdinOrReadFromArgument(args, "test_case.js", 1)
+	if err != nil {
+		log.Fatal(err)
 	}
+
+	success, message, err := client.TestCaseUpdate(testCaseUID, fileName, testCaseFile)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if success {
+		os.Exit(0)
+	}
+
+	printPrettyJSON(message)
+
+	fmt.Println()
+	os.Exit(1)
 }

--- a/cmd/testcase_update.go
+++ b/cmd/testcase_update.go
@@ -15,7 +15,7 @@ var (
 		Short: "Update an existing test case",
 		Long: `Update an existing test case
 
-<test-case-ref> can be 'organisation/test-case' or 'test-case-uid'.
+<test-case-ref> can be 'organisation-name/test-case-name' or 'test-case-uid'.
 
 Examples
 --------

--- a/cmd/testcase_validate.go
+++ b/cmd/testcase_validate.go
@@ -42,14 +42,7 @@ Examples
 				log.Fatal("Missing arguments; organization reference and test case file to validate")
 			}
 
-			candidates := []string{
-				lookupOrganisationUID(*NewClient(), args[0]),
-				readOrganisationUIDFromFile(),
-				rootOpts.DefaultOrganisation,
-			}
-
-			testCaseValidateOpts.Organisation = findFirstNonEmpty(candidates)
-
+			testCaseValidateOpts.Organisation = lookupOrganisationUID(*NewClient(), args[0])
 			if testCaseValidateOpts.Organisation == "" {
 				log.Fatal("Missing organization")
 			}

--- a/cmd/testcase_validate.go
+++ b/cmd/testcase_validate.go
@@ -39,7 +39,7 @@ Examples
 			}
 
 			if len(args) < 2 {
-				log.Fatal("Missing arguments; organization reference and test case file to validate")
+				log.Fatal("Missing arguments; organization reference and test case file to validate (or - to read from stdin)")
 			}
 
 			testCaseValidateOpts.Organisation = lookupOrganisationUID(*NewClient(), args[0])
@@ -59,29 +59,25 @@ func init() {
 }
 
 func runTestCaseValidate(cmd *cobra.Command, args []string) {
-	if len(args) > 0 {
-		fileName, testCaseFile, err := readFromStdinOrReadFromArgument(args, "test_case.js", 1)
-		if err != nil {
-			log.Fatal(err)
-		}
-
-		client := NewClient()
-
-		success, message, errValidation := client.TestCaseValidate(testCaseValidateOpts.Organisation, fileName, testCaseFile)
-		if errValidation != nil {
-			log.Fatal(errValidation)
-		}
-
-		if success {
-			fmt.Println("test case ok")
-			os.Exit(0)
-		}
-
-		printPrettyJSON(message)
-
-		fmt.Println()
-		os.Exit(1)
-	} else {
-		log.Fatal("Missing argument; test case file or - to read from stdin")
+	fileName, testCaseFile, err := readFromStdinOrReadFromArgument(args, "test_case.js", 1)
+	if err != nil {
+		log.Fatal(err)
 	}
+
+	client := NewClient()
+
+	success, message, errValidation := client.TestCaseValidate(testCaseValidateOpts.Organisation, fileName, testCaseFile)
+	if errValidation != nil {
+		log.Fatal(errValidation)
+	}
+
+	if success {
+		fmt.Println("test case ok")
+		os.Exit(0)
+	}
+
+	printPrettyJSON(message)
+
+	fmt.Println()
+	os.Exit(1)
 }

--- a/cmd/testcase_validate.go
+++ b/cmd/testcase_validate.go
@@ -18,7 +18,7 @@ var (
 We do require the organisation in order to validate the test case against
 the available resources and limits of that given organisation.
 
-<organisation-ref> is either the name or the UID of your organisation.
+<organisation-ref> is the name or the UID of your organisation.
 
 Examples
 --------

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -60,20 +60,26 @@ func findOrganisationByName(client api.Client, name string) *organisation.Organi
 	return &organisation
 }
 
-func readFromStdinOrReadFirstArgument(args []string, defaultFileName string) (fileName string, reader io.Reader, err error) {
+func readFromStdinOrReadFromArgument(args []string, defaultFileName string, argPos int) (fileName string, reader io.Reader, err error) {
 	fileName = defaultFileName
 
-	if args[0] == "-" {
+	argument := args[argPos]
+
+	if argument == "-" {
 		reader = os.Stdin
 	} else {
-		fileName = filepath.Base(args[0])
-		reader, err = os.OpenFile(args[0], os.O_RDONLY, 0755)
+		fileName = filepath.Base(argument)
+		reader, err = os.OpenFile(argument, os.O_RDONLY, 0755)
 		if err != nil {
 			return "", nil, err
 		}
 	}
 
 	return fileName, reader, err
+}
+
+func readFromStdinOrReadFirstArgument(args []string, defaultFileName string) (fileName string, reader io.Reader, err error) {
+	return readFromStdinOrReadFromArgument(args, defaultFileName, 0)
 }
 
 func printPrettyJSON(message string) {

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -150,21 +150,26 @@ func findFirstNonEmpty(candidates []string) string {
 	return ""
 }
 
+func lookupOrganisationUID(client api.Client, input string) string {
+	organisation := findOrganisationByName(client, input)
+	if organisation.ID == "" {
+		log.Fatalf("Organisation %s not found", input)
+	}
+
+	return organisation.ID
+}
+
 func lookupTestCase(client api.Client, input string) string {
 	segments := strings.Split(input, "/")
-
 	nameOrUID := input
 
 	if len(segments) == 2 {
 		organisationNameOrUID := segments[0]
 		nameOrUID = segments[1]
 
-		organisation := findOrganisationByName(client, organisationNameOrUID)
-		if organisation.ID == "" {
-			log.Fatalf("Organisation %s not found", organisationNameOrUID)
-		}
+		organisationUID := lookupOrganisationUID(client, organisationNameOrUID)
 
-		_, result, err := client.ListTestCases(organisation.ID)
+		_, result, err := client.ListTestCases(organisationUID)
 		if err != nil {
 			log.Fatal(err)
 		}


### PR DESCRIPTION
This PR enables the use of `$organisation/$testCase` to reference test cases instead of the resources' UIDs.

This is only implemented for `forge test-case {list,validate,create,update,launch}`. More commands will follow.

## Breaking Changes

The `<test-case-ref>` or `<organisation-ref>` arguments are now mandatory and organisations defined in `.stormforger-organisation` or in `stormforger.toml` are no longer used. On the plus-side the arguments are now much less confusing because they are consistent.

## Examples

List existing test cases for `tisba`'s organisation:
```
forge test-case list tisba
```

Validate a test case without saving it (within the limits of `tisba`'s organisation):
```
forge test-case validate tisba cases/simple.js
```

Create a test case (named `test_simple` inside `tisba`'s organisation):
```
forge test-case create tisba/test_simple cases/simple.js

apply-template-magic | forge test-case create tisba/test_simple -
```

Update a test case:
```
forge test-case update tisba/test_simple cases/simple.js

apply-template-magic | forge test-case update tisba/test_simple -
```


Launch a new test run:
```
forge test-case launch tisba/test_simple
```

Instead of `$organisation/$testCase` commands will interpret arguments without `/` as a UID. So `forge test-case launch XpSX5KXm` will also work.


## In other News

* add `forge test-case ls` as an alias for `list`