### PR TITLE
Support time.Duration --timeout and --wait-timeout

### DIFF
--- a/cmd/testcase_launch.go
+++ b/cmd/testcase_launch.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/google/jsonapi"
 	"github.com/spf13/cobra"
@@ -24,7 +25,7 @@ var (
 		Title        string
 		Notes        string
 		Watch        bool
-		MaxWatchTime int
+		MaxWatchTime time.Duration
 	}
 )
 
@@ -34,7 +35,7 @@ func init() {
 	testRunLaunchCmd.Flags().StringVarP(&testRunLaunchOpts.Title, "title", "t", "", "Descriptive title of test run")
 	testRunLaunchCmd.Flags().StringVarP(&testRunLaunchOpts.Notes, "notes", "n", "", "Longer description (Markdown supported)")
 	testRunLaunchCmd.Flags().BoolVarP(&testRunLaunchOpts.Watch, "watch", "w", false, "Automatically watch newly launched test run")
-	testRunLaunchCmd.Flags().IntVar(&testRunLaunchOpts.MaxWatchTime, "watch-timeout", 0, "Maximum duration in seconds to watch")
+	testRunLaunchCmd.Flags().DurationVar(&testRunLaunchOpts.MaxWatchTime, "watch-timeout", 0, "Maximum duration in seconds to watch")
 }
 
 func testRunLaunch(cmd *cobra.Command, args []string) {
@@ -55,7 +56,7 @@ func testRunLaunch(cmd *cobra.Command, args []string) {
 				log.Fatal(err)
 			}
 
-			watchTestRun(testRun.ID, testRunLaunchOpts.MaxWatchTime)
+			watchTestRun(testRun.ID, testRunLaunchOpts.MaxWatchTime.Round(time.Second).Seconds())
 		}
 
 		os.Exit(0)

--- a/cmd/testrun_watch.go
+++ b/cmd/testrun_watch.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"time"
+
 	"github.com/spf13/cobra"
 	"github.com/stormforger/cli/api"
 )
@@ -21,7 +23,7 @@ and 2 if the given timeout was exceeded.`,
 	}
 
 	testRunWatchOpts struct {
-		MaxWatchTime int
+		MaxWatchTime time.Duration
 	}
 )
 
@@ -39,11 +41,11 @@ var successStates = []string{
 func init() {
 	TestRunCmd.AddCommand(testRunWatchCmd)
 
-	testRunWatchCmd.Flags().IntVar(&testRunWatchOpts.MaxWatchTime, "timeout", 0, "Maximum duration in seconds to watch")
+	testRunWatchCmd.Flags().DurationVar(&testRunWatchOpts.MaxWatchTime, "timeout", 0, "Maximum duration in seconds to watch")
 }
 
 func testRunWatch(cmd *cobra.Command, args []string) {
-	watchTestRun(args[0], testRunWatchOpts.MaxWatchTime)
+	watchTestRun(args[0], testRunWatchOpts.MaxWatchTime.Round(time.Second).Seconds())
 }
 
 func testRunOkay(testRun *api.TestRun) bool {

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -80,7 +80,7 @@ func readOrganisationUIDFromFile() string {
 	return strings.TrimSpace(string(content))
 }
 
-func watchTestRun(testRunUID string, maxWatchTime int) {
+func watchTestRun(testRunUID string, maxWatchTime float64) {
 	client := NewClient()
 
 	started := time.Now()
@@ -103,7 +103,7 @@ func watchTestRun(testRunUID string, maxWatchTime int) {
 			os.Exit(0)
 		}
 
-		if maxWatchTime > 0 && int(runningSince) > maxWatchTime {
+		if int(maxWatchTime) > 0 && int(runningSince) > int(maxWatchTime) {
 			os.Exit(2)
 		}
 


### PR DESCRIPTION
This PR allows to write durations for arguments.

Instead of

```
forge test-case launch acme-inc/checkout --watch --watch-timeout=5400
```

you now can write it much nicer like this

```
forge test-case launch acme-inc/checkout --watch --watch-timeout=1h30m
```

If you want to use seconds, you have to add `s`: `--watch-timeout=5400s`.

The same rules apply to `forge test-run watch --timeout=…`

Note that durations will  be rounded to the nearest seconds.

Thanks @denderello for pointing this out!