### PR TITLE
Add test-case get

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -209,3 +209,26 @@ func (c *Client) doRequest(request *http.Request) ([]byte, error) {
 
 	return body, nil
 }
+
+func (c *Client) fetch(path string) (bool, []byte, error) {
+	req, err := http.NewRequest("GET", c.APIEndpoint+path, nil)
+	if err != nil {
+		return false, nil, err
+	}
+
+	response, err := c.doRequestRaw(req)
+	if err != nil {
+		return false, nil, err
+	}
+
+	body, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		return false, nil, err
+	}
+
+	if response.StatusCode != 200 {
+		return false, body, nil
+	}
+
+	return true, body, nil
+}

--- a/api/client.go
+++ b/api/client.go
@@ -60,7 +60,7 @@ func defaultHTTPClient() *http.Client {
 		IdleConnTimeout:    30 * time.Second,
 		DisableCompression: true,
 		DialTLS:            newDialer(fingerprint, false),
-		Proxy:              http.ProxyURL(getHttpProxy()),
+		Proxy:              http.ProxyURL(getHTTPProxy()),
 	}
 
 	return &http.Client{
@@ -69,19 +69,19 @@ func defaultHTTPClient() *http.Client {
 	}
 }
 
-func getHttpProxy() *url.URL {
-	httpProxyUrl := os.Getenv("HTTP_PROXY")
+func getHTTPProxy() *url.URL {
+	httpProxyURL := os.Getenv("HTTP_PROXY")
 
-	if httpProxyUrl == "" {
+	if httpProxyURL == "" {
 		return nil
 	}
 
-	proxyUrl, err := url.Parse(httpProxyUrl)
+	proxyURL, err := url.Parse(httpProxyURL)
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	return proxyUrl
+	return proxyURL
 }
 
 // Client represents the API client

--- a/api/file_fixture.go
+++ b/api/file_fixture.go
@@ -30,26 +30,6 @@ func (c *Client) MoveFileFixture(organization string, fileFixtureUID string, new
 	return string(body), nil
 }
 
-// GetFileFixture returns a list of the organizations fixtures
-func (c *Client) GetFileFixture(organization string, fileUID string) ([]byte, error) {
-	path := "/file_fixtures/" + organization + "/" + fileUID
-
-	req, err := http.NewRequest("GET", c.APIEndpoint+path, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	body, err := c.doRequest(req)
-	if err != nil {
-		return nil, err
-	}
-
-	// TODO how to opt-in for debugging?
-	// log.Println(string(body))
-
-	return body, nil
-}
-
 // ListFileFixture returns a list of the organizations fixtures
 func (c *Client) ListFileFixture(organization string) ([]byte, error) {
 	path := "/file_fixtures/" + organization + "?only=structured"

--- a/api/file_fixture.go
+++ b/api/file_fixture.go
@@ -54,17 +54,9 @@ func (c *Client) GetFileFixture(organization string, fileUID string) ([]byte, er
 func (c *Client) ListFileFixture(organization string) ([]byte, error) {
 	path := "/file_fixtures/" + organization + "?only=structured"
 
-	req, err := http.NewRequest("GET", c.APIEndpoint+path, nil)
-	if err != nil {
-		return nil, err
-	}
+	_, response, err := c.fetch(path)
 
-	body, err := c.doRequest(req)
-	if err != nil {
-		return nil, err
-	}
-
-	return body, nil
+	return response, err
 }
 
 // PushFileFixture uploads (insert or update) a file fixture
@@ -114,15 +106,7 @@ func (c *Client) DeleteFileFixture(fileFixtureUID string, organization string) (
 func (c *Client) DownloadFileFixture(organization string, fileFixtureUID string, version string) ([]byte, error) {
 	path := "/file_fixtures/" + organization + "/" + fileFixtureUID + "/download/" + version
 
-	req, err := http.NewRequest("GET", c.APIEndpoint+path, nil)
-	if err != nil {
-		return nil, err
-	}
+	_, response, err := c.fetch(path)
 
-	body, err := c.doRequest(req)
-	if err != nil {
-		return nil, err
-	}
-
-	return body, nil
+	return response, err
 }

--- a/api/organisation.go
+++ b/api/organisation.go
@@ -1,22 +1,10 @@
 package api
 
-import (
-	"net/http"
-)
-
 // ListOrganisations returns a list of organisations
 func (c *Client) ListOrganisations() ([]byte, error) {
 	path := "/organisations"
 
-	req, err := http.NewRequest("GET", c.APIEndpoint+path, nil)
-	if err != nil {
-		return nil, err
-	}
+	_, response, err := c.fetch(path)
 
-	body, err := c.doRequest(req)
-	if err != nil {
-		return nil, err
-	}
-
-	return body, nil
+	return response, err
 }

--- a/api/testcase.go
+++ b/api/testcase.go
@@ -10,26 +10,7 @@ import (
 func (c *Client) ListTestCases(organization string) (bool, []byte, error) {
 	path := "/organisations/" + organization + "/test_cases"
 
-	req, err := http.NewRequest("GET", c.APIEndpoint+path, nil)
-	if err != nil {
-		return false, nil, err
-	}
-
-	response, err := c.doRequestRaw(req)
-	if err != nil {
-		return false, nil, err
-	}
-
-	body, err := ioutil.ReadAll(response.Body)
-	if err != nil {
-		return false, nil, err
-	}
-
-	if response.StatusCode != 200 {
-		return false, body, nil
-	}
-
-	return true, body, nil
+	return c.fetch(path)
 }
 
 // TestCaseValidate will send a test case definition (JS) to the API
@@ -122,4 +103,35 @@ func (c *Client) TestCaseUpdate(testCaseUID string, fileName string, data io.Rea
 	defer response.Body.Close()
 
 	return false, string(body), nil
+}
+
+// DownloadTestCaseDefinition returns the JS definition
+// of a given test case
+func (c *Client) DownloadTestCaseDefinition(uid string) (bool, []byte, error) {
+	path := "/test_cases/" + uid + "/download"
+
+	return c.fetch(path)
+}
+
+func (c *Client) fetch(path string) (bool, []byte, error) {
+	req, err := http.NewRequest("GET", c.APIEndpoint+path, nil)
+	if err != nil {
+		return false, nil, err
+	}
+
+	response, err := c.doRequestRaw(req)
+	if err != nil {
+		return false, nil, err
+	}
+
+	body, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		return false, nil, err
+	}
+
+	if response.StatusCode != 200 {
+		return false, body, nil
+	}
+
+	return true, body, nil
 }

--- a/api/testcase.go
+++ b/api/testcase.go
@@ -3,7 +3,6 @@ package api
 import (
 	"io"
 	"io/ioutil"
-	"net/http"
 )
 
 // ListTestCases returns a list of test cases
@@ -111,27 +110,4 @@ func (c *Client) DownloadTestCaseDefinition(uid string) (bool, []byte, error) {
 	path := "/test_cases/" + uid + "/download"
 
 	return c.fetch(path)
-}
-
-func (c *Client) fetch(path string) (bool, []byte, error) {
-	req, err := http.NewRequest("GET", c.APIEndpoint+path, nil)
-	if err != nil {
-		return false, nil, err
-	}
-
-	response, err := c.doRequestRaw(req)
-	if err != nil {
-		return false, nil, err
-	}
-
-	body, err := ioutil.ReadAll(response.Body)
-	if err != nil {
-		return false, nil, err
-	}
-
-	if response.StatusCode != 200 {
-		return false, body, nil
-	}
-
-	return true, body, nil
 }

--- a/api/testrun.go
+++ b/api/testrun.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"compress/gzip"
 	"errors"
-	"fmt"
 	"io"
 	"io/ioutil"
 	"log"
@@ -39,42 +38,22 @@ type TestRun struct {
 }
 
 // TestRunList will list all test runs for a given test case
-func (c *Client) TestRunList(testCaseUID string) (TestRun, error) {
+func (c *Client) TestRunList(testCaseUID string) (bool, []byte, error) {
 	path := "/test_cases/" + testCaseUID + "/test_runs"
 
-	req, err := http.NewRequest("GET", c.APIEndpoint+path, nil)
-	if err != nil {
-		return TestRun{}, err
-	}
+	status, response, err := c.fetch(path)
 
-	body, err := c.doRequest(req)
-	if err != nil {
-		return TestRun{}, err
-	}
-
-	fmt.Println(string(body))
-
-	return TestRun{}, nil
+	return status, response, err
 }
 
 // TestRunShow will show some basic information on a given
 // test run
-func (c *Client) TestRunShow(uid string) (TestRun, error) {
+func (c *Client) TestRunShow(uid string) (bool, []byte, error) {
 	path := "/test_runs/" + uid
 
-	req, err := http.NewRequest("GET", c.APIEndpoint+path, nil)
-	if err != nil {
-		return TestRun{}, err
-	}
+	status, response, err := c.fetch(path)
 
-	body, err := c.doRequest(req)
-	if err != nil {
-		return TestRun{}, err
-	}
-
-	fmt.Println(string(body))
-
-	return TestRun{}, nil
+	return status, response, err
 }
 
 // TestRunWatch will show some basic information on a given

--- a/cmd/testcase_get.go
+++ b/cmd/testcase_get.go
@@ -1,0 +1,68 @@
+package cmd
+
+import (
+	"bytes"
+	"io"
+	"io/ioutil"
+	"log"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	// testCaseGetCmd represents the testCaseGetCmd command
+	testCaseGetCmd = &cobra.Command{
+		Use:     "get <test-case-ref> [file]",
+		Aliases: []string{"download"},
+		Short:   "Download test case definition",
+		Long: `Download the JavaScript definition of test case
+
+<test-case-ref> can be 'organisation-name/test-case-name' or 'test-case-uid'.
+
+[file] can be '-' to output to STDOUT (default) or path to file
+to write to.
+`,
+		Run: runTestCaseGet,
+		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			if len(args) < 1 {
+				log.Fatal("Missing argument: test case reference")
+			}
+
+			if len(args) > 2 {
+				log.Fatal("Too many arguments")
+			}
+		},
+	}
+)
+
+func init() {
+	TestCaseCmd.AddCommand(testCaseGetCmd)
+}
+
+func runTestCaseGet(cmd *cobra.Command, args []string) {
+	client := NewClient()
+
+	testCaseUID := lookupTestCase(*client, args[0])
+
+	success, response, err := client.DownloadTestCaseDefinition(testCaseUID)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if !success {
+		log.Fatalf("Test case definition could not be downloaded!\n%s\n", string(response))
+	}
+
+	if len(args) == 2 && args[1] != "-" {
+		err := ioutil.WriteFile(args[1], response, 0644)
+		if err != nil {
+			log.Fatal(err)
+		}
+	} else {
+		_, err := io.Copy(os.Stdout, bytes.NewReader(response))
+		if err != nil {
+			log.Fatal(err)
+		}
+	}
+}

--- a/cmd/testrun_list.go
+++ b/cmd/testrun_list.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"fmt"
 	"log"
 
 	"github.com/spf13/cobra"
@@ -27,8 +28,14 @@ func testRunList(cmd *cobra.Command, args []string) {
 
 	client := NewClient()
 
-	_, err := client.TestRunList(args[0])
+	status, response, err := client.TestRunList(args[0])
 	if err != nil {
 		log.Fatal(err)
 	}
+
+	if !status {
+		log.Fatalf("Could not fetch test run list\n%s", response)
+	}
+
+	fmt.Println(string(response))
 }

--- a/cmd/testrun_show.go
+++ b/cmd/testrun_show.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"fmt"
 	"log"
 
 	"github.com/spf13/cobra"
@@ -29,8 +30,14 @@ func init() {
 func testRunShow(cmd *cobra.Command, args []string) {
 	client := NewClient()
 
-	_, err := client.TestRunShow(args[0])
+	status, response, err := client.TestRunShow(args[0])
 	if err != nil {
 		log.Fatal(err)
 	}
+
+	if !status {
+		log.Fatalf("Could not fetch test run list\n%s", response)
+	}
+
+	fmt.Println(string(response))
 }


### PR DESCRIPTION
This PR adds `forge test-case get tisba/test_simple` which allows you to view/download the test case definition of a given test case.

## In Other News

* delint some function and variable names (`*Url` should be `*URL`, `*Http*` should be `*HTTP*`, etc.)
* remove unused Client.GetFileFixture
* add Client.fetch to reduce code duplication where the forge client simply fetches (via `GET`) from a resource