### PR TITLE
Report success if test case was updated

### DIFF
--- a/api/testcase.go
+++ b/api/testcase.go
@@ -101,7 +101,7 @@ func (c *Client) TestCaseUpdate(testCaseUID string, fileName string, data io.Rea
 
 	defer response.Body.Close()
 
-	return false, string(body), nil
+	return true, string(body), nil
 }
 
 // DownloadTestCaseDefinition returns the JS definition


### PR DESCRIPTION
In order to be able to detect when a test case was updated successfully on the CLI.