### PR TITLE
Validate argument of launch command

### DIFF
--- a/cmd/testcase_launch.go
+++ b/cmd/testcase_launch.go
@@ -33,6 +33,15 @@ Examples
 
 `,
 		Run: testRunLaunch,
+		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			if len(args) < 1 {
+				log.Fatal("Missing argument: test case reference")
+			}
+
+			if len(args) > 1 {
+				log.Fatal("Too many arguments")
+			}
+		},
 	}
 
 	testRunLaunchOpts struct {


### PR DESCRIPTION
In order to prevent panic when running the command without arguments.