### PR TITLE
Fix outputs for test case update & create commands

### DIFF
--- a/api/testcase.go
+++ b/api/testcase.go
@@ -73,6 +73,10 @@ func (c *Client) TestCaseCreate(organization string, testCaseName string, fileNa
 
 	defer response.Body.Close()
 
+	if response.StatusCode != 200 {
+		return false, string(body), nil
+	}
+
 	return true, string(body), nil
 }
 
@@ -100,6 +104,10 @@ func (c *Client) TestCaseUpdate(testCaseUID string, fileName string, data io.Rea
 	}
 
 	defer response.Body.Close()
+
+	if response.StatusCode != 200 {
+		return false, string(body), nil
+	}
 
 	return true, string(body), nil
 }

--- a/cmd/testcase_create.go
+++ b/cmd/testcase_create.go
@@ -97,11 +97,11 @@ func runTestCaseCreate(cmd *cobra.Command, args []string) {
 		log.Fatal(errValidation)
 	}
 
+	printPrettyJSON(message)
+
 	if success {
 		os.Exit(0)
 	}
-
-	printPrettyJSON(message)
 
 	fmt.Println()
 	os.Exit(1)

--- a/cmd/testcase_update.go
+++ b/cmd/testcase_update.go
@@ -60,11 +60,11 @@ func runTestCaseUpdate(cmd *cobra.Command, args []string) {
 		log.Fatal(err)
 	}
 
+	printPrettyJSON(message)
+
 	if success {
 		os.Exit(0)
 	}
-
-	printPrettyJSON(message)
 
 	fmt.Println()
 	os.Exit(1)


### PR DESCRIPTION
#34 & #36 introduced a issue, that test case create and update won't output anything, especially not in case there are issues or errors.

We eventually want to parse and process the API error responses properly, but for now, just output the API response. This way you can see errors again.