### PR TITLE
Check argument count for test-run {abort,show,watch} commands

### DIFF
--- a/cmd/testrun_abort.go
+++ b/cmd/testrun_abort.go
@@ -15,6 +15,11 @@ var (
 		Short: "Abort the given running test",
 		Long:  `Abort the given running test.`,
 		Run:   testRunAbort,
+		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			if len(args) != 1 {
+				log.Fatal("Expect exactly one argument: test run reference!")
+			}
+		},
 	}
 )
 

--- a/cmd/testrun_show.go
+++ b/cmd/testrun_show.go
@@ -16,6 +16,11 @@ var (
 		Short: "Show test run details",
 		Long:  `Show test run details.`,
 		Run:   testRunShow,
+		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			if len(args) != 1 {
+				log.Fatal("Expect exactly one argument: test run reference!")
+			}
+		},
 	}
 
 	testRunShowOpts struct {

--- a/cmd/testrun_watch.go
+++ b/cmd/testrun_watch.go
@@ -22,6 +22,11 @@ a final state (like "done" or "aborted").
 It will exit with 0 on success; 1 on test run errors (like "aborted")
 and 2 if the given timeout was exceeded.`,
 		Run: testRunWatch,
+		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			if len(args) != 1 {
+				log.Fatal("Expect exactly one argument: test run reference!")
+			}
+		},
 	}
 
 	testRunWatchOpts struct {


### PR DESCRIPTION
Better not to panic, if you forget an argument ;)

`forge test-run show` will currently panic, as `abort` and `watch`.

This PR just adds some checks to validate the number of arguments being passed.