### PR TITLE
Print test run after watching

### DIFF
--- a/cmd/testcase_launch.go
+++ b/cmd/testcase_launch.go
@@ -82,6 +82,9 @@ func testRunLaunch(cmd *cobra.Command, args []string) {
 			}
 
 			watchTestRun(testRun.ID, testRunLaunchOpts.MaxWatchTime.Round(time.Second).Seconds())
+
+			result := fetchTestRun(*client, testRun.ID)
+			fmt.Println(string(result))
 		}
 
 		os.Exit(0)

--- a/cmd/testrun_watch.go
+++ b/cmd/testrun_watch.go
@@ -1,7 +1,7 @@
 package cmd
 
 import (
-	"bytes"
+	"fmt"
 	"log"
 	"time"
 
@@ -56,13 +56,10 @@ func testRunWatch(cmd *cobra.Command, args []string) {
 
 	testRunUID := getTestRunUID(*client, args[0])
 
-	result := fetchTestRun(*client, testRunUID)
-	testRun, err := testrun.UnmarshalSingle(bytes.NewReader(result))
-	if err != nil {
-		log.Fatal(err)
-	}
+	watchTestRun(testRunUID, testRunWatchOpts.MaxWatchTime.Round(time.Second).Seconds())
 
-	watchTestRun(testRun.ID, testRunWatchOpts.MaxWatchTime.Round(time.Second).Seconds())
+	result := fetchTestRun(*client, testRunUID)
+	fmt.Println(string(result))
 }
 
 func testRunOkay(testRun *testrun.TestRun) bool {

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -139,7 +139,7 @@ func watchTestRun(testRunUID string, maxWatchTime float64) {
 		}
 
 		if testRunSuccess(&testRun) {
-			os.Exit(0)
+			return
 		}
 
 		if int(maxWatchTime) > 0 && int(runningSince) > int(maxWatchTime) {


### PR DESCRIPTION
We did not print the full test run "result"/show after `forge test-case launch foo/bar --watch` or `forge test-run watch foo/bar/23`. This is pretty useful though, because the current short output does not contain the test run summary, like basic statistics, checks and counters etc.

This PR also eliminates redundant calls to fetch test runs :)