### PR TITLE
Added new command to get a dump file for test runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ You can...
 * list all test runs of a test case: `forge test-run list acme-inc/checkout`
 * show details: `forge test-run show acme-inc/checkout/42`
 * view logs: `forge test-run logs acme-inc/checkout/42`
+* view full traffic dump: `forge test-run dump acme-inc/checkout/42`
 
 
 ### Data Sources

--- a/cmd/testrun_dump.go
+++ b/cmd/testrun_dump.go
@@ -15,15 +15,16 @@ var (
 		Short: "Fetch the the test runs dump file (request/response log)",
 		Long: `Will fetch the the test runs dump file (request/response log).
 
-The call log contains: FIXME
-	* time (epoch in seconds)
-	* HTTP verb
-	* HTTP host
-	* request path
-	* HTTP Status Code
-	* response size (in Bytes)
-	* duration (in ms)
-	* request tag`,
+The dump file contains:
+	* Request
+	  * Method
+	  * Path with query params
+	  * Host
+	  * Header
+	* Response
+	  * HTTP status code
+	  * Header
+	  * Body`,
 		Run:              runTestRunDumpOptions,
 		PersistentPreRun: ensureTestRunDumpOptions,
 	}

--- a/cmd/testrun_dump.go
+++ b/cmd/testrun_dump.go
@@ -9,22 +9,17 @@ import (
 )
 
 var (
-	// dumpCmd represents the dump command
 	dumpCmd = &cobra.Command{
 		Use:   "dump <test-run-ref>",
-		Short: "Fetch the the test runs dump file (request/response log)",
-		Long: `Will fetch the the test runs dump file (request/response log).
+		Short: "Fetch traffic dump (if available)",
+		Long: `Will fetch the test run's traffic dump file.
 
-The dump file contains:
-	* Request
-	  * Method
-	  * Path with query params
-	  * Host
-	  * Header
-	* Response
-	  * HTTP status code
-	  * Header
-	  * Body`,
+If enabled for the given test run, the traffic dump will
+contain a "close to the wire" dump of all requests and responses.
+
+The main purpose is for debugging as the traffic dump is
+in no way analyzed or processed.
+`,
 		Run:              runTestRunDumpOptions,
 		PersistentPreRun: ensureTestRunDumpOptions,
 	}
@@ -38,7 +33,7 @@ The dump file contains:
 func init() {
 	TestRunCmd.AddCommand(dumpCmd)
 
-	dumpCmd.Flags().StringVar(&dumpOpts.OutputFile, "file", "-", "save logs to file or '-' for stdout")
+	dumpCmd.Flags().StringVar(&dumpOpts.OutputFile, "file", "-", "save traffic dump to file or '-' for stdout")
 }
 
 func ensureTestRunDumpOptions(cmd *cobra.Command, args []string) {

--- a/cmd/testrun_dump.go
+++ b/cmd/testrun_dump.go
@@ -1,0 +1,77 @@
+package cmd
+
+import (
+	"io"
+	"log"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	// dumpCmd represents the dump command
+	dumpCmd = &cobra.Command{
+		Use:   "dump <test-run-ref>",
+		Short: "Fetch the the test runs dump file (request/response log)",
+		Long: `Will fetch the the test runs dump file (request/response log).
+
+The call log contains: FIXME
+	* time (epoch in seconds)
+	* HTTP verb
+	* HTTP host
+	* request path
+	* HTTP Status Code
+	* response size (in Bytes)
+	* duration (in ms)
+	* request tag`,
+		Run:              runTestRunDumpOptions,
+		PersistentPreRun: ensureTestRunDumpOptions,
+	}
+
+	dumpOpts struct {
+		Type       string
+		OutputFile string
+	}
+)
+
+func init() {
+	TestRunCmd.AddCommand(dumpCmd)
+
+	dumpCmd.Flags().StringVar(&dumpOpts.OutputFile, "file", "-", "save logs to file or '-' for stdout")
+}
+
+func ensureTestRunDumpOptions(cmd *cobra.Command, args []string) {
+	if len(args) != 1 {
+		log.Fatal("Expecting exactly one argument: Test Run Reference")
+	}
+}
+
+func runTestRunDumpOptions(cmd *cobra.Command, args []string) {
+	client := NewClient()
+
+	testRunUID := getTestRunUID(*client, args[0])
+
+	reader, err := client.TestRunDump(testRunUID)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if dumpOpts.OutputFile == "-" {
+		_, err = io.Copy(os.Stdout, reader)
+		if err != nil {
+			log.Fatal(err)
+		}
+	} else {
+		file, err := os.Create(dumpOpts.OutputFile)
+		if err != nil {
+			log.Fatal(err)
+		}
+		defer file.Close()
+		defer reader.Close()
+
+		_, err = io.Copy(file, reader)
+		if err != nil {
+			log.Fatal(err)
+		}
+	}
+}

--- a/cmd/testrun_logs.go
+++ b/cmd/testrun_logs.go
@@ -13,8 +13,8 @@ var (
 	// calllogCmd represents the calllog command
 	calllogCmd = &cobra.Command{
 		Use:   "logs <test-run-ref>",
-		Short: "Fetch the the test runs call log (request log)",
-		Long: `Will fetch the the test runs call log (request log).
+		Short: "Fetch call log (request log)",
+		Long: `Will fetch the test run's call log (request log).
 
 By default, you will get the first 10k lines. Using --full you
 will download the entire request log.


### PR DESCRIPTION
We want to view the full traffic dump via cli. 
This PR adds a new command for test runs, example: `forge test-run dump [test_run_uid]`.
