### PR TITLE
Test Run NFR

### DIFF
--- a/api/testrun.go
+++ b/api/testrun.go
@@ -117,6 +117,8 @@ func (c *Client) TestRunCallLog(pathID string, preview bool) (io.ReadCloser, err
 	return reader, nil
 }
 
+// TestRunDump will fetch a traffic dump for a
+// given test run if it is available.
 func (c *Client) TestRunDump(pathID string) (io.ReadCloser, error) {
 	testRun := ExtractTestRunResources(pathID)
 
@@ -201,6 +203,33 @@ func (c *Client) TestRunAbort(testRunUID string) (bool, string, error) {
 	defer response.Body.Close()
 
 	return response.StatusCode < 400, string(body), nil
+}
+
+// TestRunNfrCheck will upload requirements definition
+// and checks if the given test run matches them.
+func (c *Client) TestRunNfrCheck(uid string, fileName string, data io.Reader) (bool, []byte, error) {
+	extraParams := map[string]string{}
+
+	path := "/test_runs/" + uid + "/check_nfr"
+
+	req, err := fileUploadRequest(c.APIEndpoint+path, "POST", extraParams, "nfr_file", fileName, "application/x-yaml", data)
+
+	resp, err := c.doRequestRaw(req)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return false, nil, err
+	}
+
+	err = resp.Body.Close()
+	if err != nil {
+		return false, nil, err
+	}
+
+	return true, body, nil
 }
 
 // ExtractTestRunResources will try to extract information to the

--- a/api/testrun.go
+++ b/api/testrun.go
@@ -214,22 +214,22 @@ func (c *Client) TestRunNfrCheck(uid string, fileName string, data io.Reader) (b
 
 	req, err := fileUploadRequest(c.APIEndpoint+path, "POST", extraParams, "nfr_file", fileName, "application/x-yaml", data)
 
-	resp, err := c.doRequestRaw(req)
+	response, err := c.doRequestRaw(req)
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := ioutil.ReadAll(response.Body)
 	if err != nil {
 		return false, nil, err
 	}
 
-	err = resp.Body.Close()
+	err = response.Body.Close()
 	if err != nil {
 		return false, nil, err
 	}
 
-	return true, body, nil
+	return response.StatusCode < 400, body, nil
 }
 
 // ExtractTestRunResources will try to extract information to the

--- a/api/testrun/main.go
+++ b/api/testrun/main.go
@@ -95,3 +95,21 @@ func UnmarshalNfrResults(input io.Reader) (NfrResultList, error) {
 
 	return result, nil
 }
+
+// SubjectWithUnit formats the expectation inclusing the subject's unit
+func (nfr *NfrResult) SubjectWithUnit() string {
+	if nfr.SubjectUnit != "" {
+		return nfr.Subject + " " + nfr.SubjectUnit
+	}
+
+	return nfr.Subject
+}
+
+// ExpectationWithUnit formats the expectation inclusing the subject's unit
+func (nfr *NfrResult) ExpectationWithUnit() string {
+	if nfr.SubjectUnit != "" {
+		return nfr.Expectation + " " + nfr.SubjectUnit
+	}
+
+	return nfr.Expectation
+}

--- a/api/testrun/main.go
+++ b/api/testrun/main.go
@@ -35,6 +35,7 @@ type NfrResult struct {
 	ID          string `jsonapi:"primary,nfr_results"`
 	Success     bool   `jsonapi:"attr,success"`
 	Subject     string `jsonapi:"attr,subject"`
+	SubjectUnit string `jsonapi:"attr,subject_unit"`
 	Expectation string `jsonapi:"attr,expectation"`
 	Type        string `jsonapi:"attr,nfr_type"`
 	Disabled    bool   `jsonapi:"attr,disabled"`

--- a/api/testrun/main.go
+++ b/api/testrun/main.go
@@ -25,6 +25,23 @@ type TestRun struct {
 	EndedAt   string `jsonapi:"attr,ended_at,omitempty"`
 }
 
+// NfrResultList is a list of NFR results
+type NfrResultList struct {
+	NfrResults []*NfrResult
+}
+
+// NfrResult describes a NFR check result
+type NfrResult struct {
+	ID          string `jsonapi:"primary,nfr_results"`
+	Success     bool   `jsonapi:"attr,success"`
+	Subject     string `jsonapi:"attr,subject"`
+	Expectation string `jsonapi:"attr,expectation"`
+	Type        string `jsonapi:"attr,nfr_type"`
+	Disabled    bool   `jsonapi:"attr,disabled"`
+	Filter      string `jsonapi:"attr,filter"`
+	Metric      string `jsonapi:"attr,metric"`
+}
+
 // Unmarshal unmarshals a list of TestRun records
 func Unmarshal(input io.Reader) (List, error) {
 	items, err := jsonapi.UnmarshalManyPayload(input, reflect.TypeOf(new(TestRun)))
@@ -55,4 +72,25 @@ func UnmarshalSingle(input io.Reader) (TestRun, error) {
 	}
 
 	return *item, nil
+}
+
+// UnmarshalNfrResults unmarshals a list of NFR result records
+func UnmarshalNfrResults(input io.Reader) (NfrResultList, error) {
+	items, err := jsonapi.UnmarshalManyPayload(input, reflect.TypeOf(new(NfrResult)))
+	if err != nil {
+		return NfrResultList{}, err
+	}
+
+	result := NfrResultList{}
+
+	for _, item := range items {
+		typedItem, ok := item.(*NfrResult)
+		if !ok {
+			return NfrResultList{}, fmt.Errorf("Type assertion failed")
+		}
+
+		result.NfrResults = append(result.NfrResults, typedItem)
+	}
+
+	return result, nil
 }

--- a/cmd/testrun_nfr.go
+++ b/cmd/testrun_nfr.go
@@ -1,0 +1,97 @@
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/fatih/color"
+	"github.com/spf13/cobra"
+	"github.com/stormforger/cli/api/testrun"
+)
+
+var (
+	testRunNfrCmd = &cobra.Command{
+		Use:   "nfr <test-run-ref> <requirements_file>",
+		Short: "Check test run against NFR",
+		Long:  `Check test run against non-functional requirements.`,
+		Run:   testRunNfrRun,
+	}
+)
+
+func init() {
+	TestRunCmd.AddCommand(testRunNfrCmd)
+}
+
+func testRunNfrRun(cmd *cobra.Command, args []string) {
+	client := NewClient()
+
+	testRunUID := getTestRunUID(*client, args[0])
+
+	fileName, file, err := readFromStdinOrReadFromArgument(args, "nfr.yml", 1)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	status, result, err := client.TestRunNfrCheck(testRunUID, fileName, file)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if rootOpts.OutputFormat == "json" {
+		fmt.Println(string(result))
+		return
+	}
+
+	if !status {
+		log.Fatalf("Could not fetch test run list\n%s", result)
+	}
+
+	items, err := testrun.UnmarshalNfrResults(bytes.NewReader(result))
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	green := color.New(color.FgGreen).SprintFunc()
+	red := color.New(color.FgRed).SprintFunc()
+	redBg := color.New(color.BgRed).Add(color.FgWhite).SprintFunc()
+	white := color.New(color.FgWhite).SprintFunc()
+
+	checkStatus := ""
+	anyFails := false
+	for _, item := range items.NfrResults {
+		if !item.Disabled {
+			actualSubject := ""
+			if item.Success {
+				checkStatus = green("\u2713")
+				actualSubject = fmt.Sprintf("was %s", item.Subject)
+			} else {
+				anyFails = true
+				checkStatus = red("\u2717")
+				actualSubject = fmt.Sprintf("but actually was %s", item.Subject)
+			}
+
+			filter := ""
+			if item.Filter != "null" {
+				filter = " (" + item.Filter + ")"
+			}
+
+			fmt.Printf(
+				"%s %s expected to be %s; %s (%s)%s\n",
+				checkStatus,
+				item.Metric,
+				item.Expectation,
+				actualSubject,
+				item.Type,
+				filter,
+			)
+		} else {
+			fmt.Printf("%s %s (%s) %s\n", white("?"), red("TODO item.Expectation"), item.Type, redBg("DISABLED"))
+		}
+	}
+
+	if anyFails {
+		os.Exit(1)
+	}
+}

--- a/cmd/testrun_nfr.go
+++ b/cmd/testrun_nfr.go
@@ -65,11 +65,11 @@ func testRunNfrRun(cmd *cobra.Command, args []string) {
 			actualSubject := ""
 			if item.Success {
 				checkStatus = green("\u2713")
-				actualSubject = fmt.Sprintf("was %s", item.Subject)
+				actualSubject = fmt.Sprintf("was %s", item.SubjectWithUnit())
 			} else {
 				anyFails = true
 				checkStatus = red("\u2717")
-				actualSubject = fmt.Sprintf("but actually was %s", item.Subject)
+				actualSubject = fmt.Sprintf("but actually was %s", item.SubjectWithUnit())
 			}
 
 			filter := ""
@@ -81,8 +81,8 @@ func testRunNfrRun(cmd *cobra.Command, args []string) {
 				"%s %s expected to be %s; %s (%s)%s\n",
 				checkStatus,
 				item.Metric,
-				item.Expectation+" "+item.SubjectUnit,
-				actualSubject+" "+item.SubjectUnit,
+				item.ExpectationWithUnit(),
+				actualSubject,
 				item.Type,
 				filter,
 			)
@@ -92,7 +92,7 @@ func testRunNfrRun(cmd *cobra.Command, args []string) {
 				white("?"),
 				redBg("DISABLED"),
 				item.Metric,
-				item.Expectation+" "+item.SubjectUnit,
+				item.ExpectationWithUnit(),
 				item.Type,
 			)
 		}

--- a/cmd/testrun_nfr.go
+++ b/cmd/testrun_nfr.go
@@ -81,13 +81,20 @@ func testRunNfrRun(cmd *cobra.Command, args []string) {
 				"%s %s expected to be %s; %s (%s)%s\n",
 				checkStatus,
 				item.Metric,
-				item.Expectation,
-				actualSubject,
+				item.Expectation+" "+item.SubjectUnit,
+				actualSubject+" "+item.SubjectUnit,
 				item.Type,
 				filter,
 			)
 		} else {
-			fmt.Printf("%s %s (%s) %s\n", white("?"), red("TODO item.Expectation"), item.Type, redBg("DISABLED"))
+			fmt.Printf(
+				"%s %s expected to be %s (%s) %s\n",
+				white("?"),
+				item.Metric,
+				item.Expectation+" "+item.SubjectUnit,
+				item.Type,
+				redBg("DISABLED"),
+			)
 		}
 	}
 

--- a/cmd/testrun_nfr.go
+++ b/cmd/testrun_nfr.go
@@ -45,7 +45,7 @@ func testRunNfrRun(cmd *cobra.Command, args []string) {
 	}
 
 	if !status {
-		log.Fatalf("Could not fetch test run list\n%s", result)
+		log.Fatalf("Could not perform test run NFR checks...\n%s", result)
 	}
 
 	items, err := testrun.UnmarshalNfrResults(bytes.NewReader(result))

--- a/cmd/testrun_nfr.go
+++ b/cmd/testrun_nfr.go
@@ -88,12 +88,12 @@ func testRunNfrRun(cmd *cobra.Command, args []string) {
 			)
 		} else {
 			fmt.Printf(
-				"%s %s expected to be %s (%s) %s\n",
+				"%s %s %s expected to be %s (%s)\n",
 				white("?"),
+				redBg("DISABLED"),
 				item.Metric,
 				item.Expectation+" "+item.SubjectUnit,
 				item.Type,
-				redBg("DISABLED"),
 			)
 		}
 	}

--- a/cmd/testrun_nfr.go
+++ b/cmd/testrun_nfr.go
@@ -73,8 +73,8 @@ func testRunNfrRun(cmd *cobra.Command, args []string) {
 			}
 
 			filter := ""
-			if item.Filter != "null" {
-				filter = " (" + item.Filter + ")"
+			if item.Filter != "null" && item.Filter != "" {
+				filter = " (where: " + item.Filter + ")"
 			}
 
 			fmt.Printf(

--- a/testdata/nfr/simple.yml
+++ b/testdata/nfr/simple.yml
@@ -2,24 +2,26 @@ version: "0.1"
 
 requirements:
 - test.completed: true
-- test.cluster.utilization:
-    metric:
-      main: cpu
-      sub: total_avg
+- test.cluster.utilization.cpu:
+    select: total_avg
     test: ["<=", 60]
 - test.duration: [">", 600]
 
 # require overall p99 latency to be below 9 sec
 - http.latency:
     enabled: false
-    metric: p99_0
+    select:
+      type: percentile
+      value: 99
     test: ["<=", 9000]
 
 # require p99 latency of ec-purchase-card-discount tags with HTTP 504 status
-# to be below 5 select
+# to be below 5 sec
 - http.latency:
-    metric: p99_0
     select:
-      status: ["=", 504]
+      type: percentile
+      value: 99
+    where:
+      status: ["<", 500]
       tag: ec-purchase-card-discount
     test: ["<", 5000]

--- a/testdata/nfr/simple.yml
+++ b/testdata/nfr/simple.yml
@@ -1,0 +1,25 @@
+version: "0.1"
+
+requirements:
+- test.completed: true
+- test.cluster.utilization:
+    metric:
+      main: cpu
+      sub: total_avg
+    test: ["<=", 60]
+- test.duration: [">", 600]
+
+# require overall p99 latency to be below 9 sec
+- http.latency:
+    enabled: false
+    metric: p99_0
+    test: ["<=", 9000]
+
+# require p99 latency of ec-purchase-card-discount tags with HTTP 504 status
+# to be below 5 select
+- http.latency:
+    metric: p99_0
+    select:
+      status: ["=", 504]
+      tag: ec-purchase-card-discount
+    test: ["<", 5000]

--- a/testdata/nfr/simple.yml
+++ b/testdata/nfr/simple.yml
@@ -20,7 +20,7 @@ requirements:
 - http.latency:
     select:
       type: percentile
-      value: 99
+      value: 95
     where:
       status: ["<", 500]
       tag: ec-purchase-card-discount

--- a/testdata/nfr/simple.yml
+++ b/testdata/nfr/simple.yml
@@ -3,7 +3,7 @@ version: "0.1"
 requirements:
 - test.completed: true
 - test.cluster.utilization.cpu:
-    select: total_avg
+    select: average
     test: ["<=", 60]
 - test.duration: [">", 600]
 


### PR DESCRIPTION
This PR adds the `test-run nfr` subcommand to check if a finished test run passes your non-functional requirements.

Given the following YML file:

```yml
version: "0.1"

requirements:
- test.completed: true
- test.cluster.utilization.cpu:
    select: total_avg
    test: ["<=", 60]
- test.duration: [">", 600]

# require overall p99 latency to be below 9 sec
- http.latency:
    enabled: false
    select:
      type: percentile
      value: 99
    test: ["<=", 9000]

# require p99 latency of ec-purchase-card-discount tags with HTTP status < 500
# to be below 5 sec
- http.latency:
    select:
      type: percentile
      value: 99
    where:
      status: ["<", 500]
      tag:
      - ec-purchase-card-discount
    test: ["<", 5000]
```

You can do

```
forge test-run nfr acme-inc/shop/42 nfr/blackfriday.yml
```

and see if your test run passes your defined non-functional requirements:

![screen shot 2018-05-28 at 16 13 42](https://user-images.githubusercontent.com/75156/40618568-2916a5f0-6292-11e8-86a7-18b1c15bdad9.png)

If the checks fail, `forge` will exit with non-zero.

## Note

This feature is in a beta state. The YML format, especially the rules and structures are subject to change.