### PR TITLE
Data Source Commands: Allow non UID references

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -194,22 +194,6 @@ func (c *Client) doRequestRaw(request *http.Request) (*http.Response, error) {
 	return response, nil
 }
 
-func (c *Client) doRequest(request *http.Request) ([]byte, error) {
-	response, err := c.doRequestRaw(request)
-
-	if err != nil {
-		return nil, err
-	}
-
-	body, err := ioutil.ReadAll(response.Body)
-	if err != nil {
-		return nil, err
-	}
-	defer response.Body.Close()
-
-	return body, nil
-}
-
 // LookupAndFetchResource tries to download a given resource from the API
 func (c *Client) LookupAndFetchResource(resourceType string, input string) (bool, []byte, error) {
 	return c.FetchResource("/lookup?type=" + resourceType + "&q=" + input)

--- a/api/file_fixture.go
+++ b/api/file_fixture.go
@@ -83,7 +83,7 @@ func (c *Client) PushFileFixture(fileName string, data io.Reader, organization s
 
 	defer response.Body.Close()
 
-	if response.StatusCode != 200 {
+	if response.StatusCode >= 300 {
 		return false, string(body), nil
 	}
 
@@ -109,7 +109,7 @@ func (c *Client) DeleteFileFixture(fileFixtureUID string, organization string) (
 
 	defer response.Body.Close()
 
-	if response.StatusCode != 200 {
+	if response.StatusCode >= 300 {
 		return false, string(body), nil
 	}
 

--- a/api/file_fixture.go
+++ b/api/file_fixture.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"io"
+	"io/ioutil"
 	"net/http"
 )
 
@@ -14,33 +15,44 @@ type FileFixtureParams struct {
 }
 
 // MoveFileFixture renames a filefixtures
-func (c *Client) MoveFileFixture(organization string, fileFixtureUID string, newName string) (string, error) {
+func (c *Client) MoveFileFixture(organization string, fileFixtureUID string, newName string) (bool, string, error) {
 	params := map[string]string{"file_fixture[name]": newName}
 
 	req, err := newPatchRequest(c.APIEndpoint+"/file_fixtures/"+organization+"/"+fileFixtureUID, params)
 	if err != nil {
-		return "", err
+		return false, "", err
 	}
 
-	body, err := c.doRequest(req)
+	response, err := c.doRequestRaw(req)
 	if err != nil {
-		return "", err
+		return false, "", err
 	}
 
-	return string(body), nil
+	body, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		return false, "", err
+	}
+
+	defer response.Body.Close()
+
+	if response.StatusCode != 200 {
+		return false, string(body), nil
+	}
+
+	return true, string(body), nil
 }
 
 // ListFileFixture returns a list of the organizations fixtures
-func (c *Client) ListFileFixture(organization string) ([]byte, error) {
+func (c *Client) ListFileFixture(organization string) (bool, []byte, error) {
 	path := "/file_fixtures/" + organization + "?only=structured"
 
-	_, response, err := c.fetch(path)
+	success, response, err := c.fetch(path)
 
-	return response, err
+	return success, response, err
 }
 
 // PushFileFixture uploads (insert or update) a file fixture
-func (c *Client) PushFileFixture(fileName string, data io.Reader, organization string, params *FileFixtureParams) (string, error) {
+func (c *Client) PushFileFixture(fileName string, data io.Reader, organization string, params *FileFixtureParams) (bool, string, error) {
 	extraParams := map[string]string{
 		"file_fixture[name]": params.Name,
 		"file_fixture[type]": params.Type,
@@ -56,37 +68,59 @@ func (c *Client) PushFileFixture(fileName string, data io.Reader, organization s
 
 	req, err := fileUploadRequest(c.APIEndpoint+"/file_fixtures/"+organization, "POST", extraParams, "file_fixture[file_fixture_version][original]", fileName, "application/octet-stream", data)
 	if err != nil {
-		return "", err
+		return false, "", err
 	}
 
-	body, err := c.doRequest(req)
+	response, err := c.doRequestRaw(req)
 	if err != nil {
-		return "", err
+		return false, "", err
 	}
 
-	return string(body), nil
+	body, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		return false, "", err
+	}
+
+	defer response.Body.Close()
+
+	if response.StatusCode != 200 {
+		return false, string(body), nil
+	}
+
+	return true, string(body), nil
 }
 
 // DeleteFileFixture deletes a file fixture
-func (c *Client) DeleteFileFixture(fileFixtureUID string, organization string) (string, error) {
+func (c *Client) DeleteFileFixture(fileFixtureUID string, organization string) (bool, string, error) {
 	req, err := http.NewRequest("DELETE", c.APIEndpoint+"/file_fixtures/"+organization+"/"+fileFixtureUID, nil)
 	if err != nil {
-		return "", err
+		return false, "", err
 	}
 
-	body, err := c.doRequest(req)
+	response, err := c.doRequestRaw(req)
 	if err != nil {
-		return "", err
+		return false, "", err
 	}
 
-	return string(body), nil
+	body, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		return false, "", err
+	}
+
+	defer response.Body.Close()
+
+	if response.StatusCode != 200 {
+		return false, string(body), nil
+	}
+
+	return true, string(body), nil
 }
 
 // DownloadFileFixture retrieves the originally uploaded file
-func (c *Client) DownloadFileFixture(organization string, fileFixtureUID string, version string) ([]byte, error) {
+func (c *Client) DownloadFileFixture(organization string, fileFixtureUID string, version string) (bool, []byte, error) {
 	path := "/file_fixtures/" + organization + "/" + fileFixtureUID + "/download/" + version
 
-	_, response, err := c.fetch(path)
+	success, response, err := c.fetch(path)
 
-	return response, err
+	return success, response, err
 }

--- a/api/filefixture/main.go
+++ b/api/filefixture/main.go
@@ -36,8 +36,8 @@ type Version struct {
 	UpdatedAt  string   `jsonapi:"attr,updated_at"`
 }
 
-// UnmarshalFileFixtures unmarshals a list of FileFixture records
-func UnmarshalFileFixtures(input io.Reader) (List, error) {
+// Unmarshal unmarshals a list of FileFixture records
+func Unmarshal(input io.Reader) (List, error) {
 	items, err := jsonapi.UnmarshalManyPayload(input, reflect.TypeOf(new(FileFixture)))
 	if err != nil {
 		return List{}, err

--- a/api/filefixture/main.go
+++ b/api/filefixture/main.go
@@ -31,6 +31,7 @@ type Version struct {
 	ID         string   `jsonapi:"primary,file_fixture_version_structureds"`
 	Hash       string   `jsonapi:"attr,hash"`
 	FileSize   int      `jsonapi:"attr,file_size"`
+	ItemCount  int      `jsonapi:"attr,item_count"`
 	FieldNames []string `jsonapi:"attr,field_names"`
 	CreatedAt  string   `jsonapi:"attr,created_at"`
 	UpdatedAt  string   `jsonapi:"attr,updated_at"`
@@ -108,6 +109,7 @@ func ShowDetails(fileFixture *FileFixture) {
 	fmt.Printf("Current Version: %s\n", fileFixture.CurrentVersion.ID)
 	fmt.Printf("  SHA256 Hash:   %s\n", fileFixture.CurrentVersion.Hash)
 	fmt.Printf("  Size:          %s\n", humanize.Bytes(uint64(fileFixture.CurrentVersion.FileSize)))
+	fmt.Printf("  Line Count:    %v\n", fileFixture.CurrentVersion.ItemCount)
 	fmt.Printf("  Created:       %s (%s)\n", convertToLocalTZ(fixtureCurrentVersionCreatedAt), humanize.Time(fixtureCurrentVersionCreatedAt))
 	fmt.Printf("Version(s):      %v\n", len(fileFixture.Versions))
 	for _, version := range fileFixture.Versions {

--- a/cmd/datasource.go
+++ b/cmd/datasource.go
@@ -1,24 +1,12 @@
 package cmd
 
-import (
-	"log"
-
-	"github.com/spf13/cobra"
-)
+import "github.com/spf13/cobra"
 
 var (
 	datasourceCmd = &cobra.Command{
 		Use:     "datasource",
 		Aliases: []string{"ds"},
 		Short:   "Work with and manage data sources",
-
-		PersistentPreRun: func(cmd *cobra.Command, args []string) {
-			datasourceOpts.Organisation = findFirstNonEmpty([]string{datasourceOpts.Organisation, readOrganisationUIDFromFile(), rootOpts.DefaultOrganisation})
-
-			if datasourceOpts.Organisation == "" {
-				log.Fatal("Missing organization")
-			}
-		},
 	}
 
 	datasourceOpts struct {

--- a/cmd/datasource_list.go
+++ b/cmd/datasource_list.go
@@ -2,7 +2,9 @@ package cmd
 
 import (
 	"bytes"
+	"fmt"
 	"log"
+	"os"
 
 	"github.com/spf13/cobra"
 	"github.com/stormforger/cli/api/filefixture"
@@ -10,10 +12,24 @@ import (
 
 var (
 	datasourceListCmd = &cobra.Command{
-		Use:     "ls",
+		Use:     "ls <organization-ref>",
 		Aliases: []string{"list"},
 		Short:   "List fixtures",
 		Run:     runDataSourceList,
+		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			if len(args) > 1 {
+				log.Fatal("Too many arguments")
+			}
+
+			if len(args) < 1 {
+				log.Fatal("Missing organization")
+			}
+
+			datasourceOpts.Organisation = lookupOrganisationUID(*NewClient(), args[0])
+			if datasourceOpts.Organisation == "" {
+				log.Fatal("Missing organization")
+			}
+		},
 	}
 )
 
@@ -24,10 +40,33 @@ func init() {
 func runDataSourceList(cmd *cobra.Command, args []string) {
 	client := NewClient()
 
-	result, err := client.ListFileFixture(datasourceOpts.Organisation)
+	success, result, err := client.ListFileFixture(datasourceOpts.Organisation)
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	filefixture.ShowName(bytes.NewReader(result))
+	if !success {
+		fmt.Fprintln(os.Stderr, "Could not list data sources!")
+		fmt.Fprintln(os.Stderr, string(result))
+
+		os.Exit(1)
+	}
+
+	if rootOpts.OutputFormat == "json" {
+		fmt.Println(string(result))
+		return
+	}
+
+	items, err := filefixture.Unmarshal(bytes.NewReader(result))
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	for _, item := range items.Fixtures {
+		if rootOpts.OutputFormat == "human" {
+			fmt.Printf("%s (ID: %s)\n", item.Name, item.ID)
+		} else {
+			fmt.Printf("%s\n", item.Name)
+		}
+	}
 }

--- a/cmd/datasource_move.go
+++ b/cmd/datasource_move.go
@@ -3,17 +3,27 @@ package cmd
 import (
 	"fmt"
 	"log"
+	"os"
 
 	"github.com/spf13/cobra"
 )
 
 var (
 	datasourceMoveCmd = &cobra.Command{
-		Use:              "mv",
-		Aliases:          []string{"move", "rename"},
-		Short:            "Rename a fixture",
-		Run:              runDataSourceMove,
-		PersistentPreRun: ensureDatasourceMoveOptions,
+		Use:     "mv <organization-ref> <name> <new-name>",
+		Aliases: []string{"move", "rename"},
+		Short:   "Rename a fixture",
+		Run:     runDataSourceMove,
+		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			if len(args) != 3 {
+				log.Fatal("Expecting exactly three arguments: organisation, name of source and destination")
+			}
+
+			datasourceOpts.Organisation = lookupOrganisationUID(*NewClient(), args[0])
+			if datasourceOpts.Organisation == "" {
+				log.Fatal("Missing organization")
+			}
+		},
 	}
 )
 
@@ -21,29 +31,27 @@ func init() {
 	datasourceCmd.AddCommand(datasourceMoveCmd)
 }
 
-func ensureDatasourceMoveOptions(cmd *cobra.Command, args []string) {
-	if len(args) != 2 {
-		log.Fatal("Expecting exactly two arguments: name of source and destination")
-	}
-
-	datasourceOpts.Organisation = findFirstNonEmpty([]string{datasourceOpts.Organisation, readOrganisationUIDFromFile(), rootOpts.DefaultOrganisation})
-
-	if datasourceOpts.Organisation == "" {
-		log.Fatal("Missing organization")
-	}
-}
-
 func runDataSourceMove(cmd *cobra.Command, args []string) {
 	client := NewClient()
-	fileName := args[0]
-	newFileName := args[1]
+	fileName := args[1]
+	newFileName := args[2]
 
 	fileFixture := findFixtureByName(*client, datasourceOpts.Organisation, fileName)
 
-	result, err := client.MoveFileFixture(datasourceOpts.Organisation, fileFixture.ID, newFileName)
+	success, result, err := client.MoveFileFixture(datasourceOpts.Organisation, fileFixture.ID, newFileName)
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	fmt.Println(result)
+	if !success {
+		fmt.Fprintln(os.Stderr, "Could not move data source!")
+		fmt.Fprintln(os.Stderr, string(result))
+
+		os.Exit(1)
+	}
+
+	if rootOpts.OutputFormat == "json" {
+		fmt.Println(string(result))
+		return
+	}
 }

--- a/cmd/datasource_push.go
+++ b/cmd/datasource_push.go
@@ -104,6 +104,10 @@ func runDataSourcePush(cmd *cobra.Command, args []string) {
 			os.Exit(1)
 		}
 
-		fmt.Println(result)
+		if rootOpts.OutputFormat == "json" {
+			fmt.Println(string(result))
+		} else {
+			fmt.Printf("Uploaded %v successfully!\n", params.Name)
+		}
 	}
 }

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -69,7 +69,7 @@ func runLogin(cmd *cobra.Command, args []string) {
 			setupConfig()
 		} else {
 			color.White("\nLogin successful!\n\n")
-			color.Red("Found %s. File will not be overriden!\n\n", stormforgerConfig)
+			color.Red("Found %s. File will not be overridden!\n\n", stormforgerConfig)
 			color.White("Add the JWT token to a .stormforger.toml file like this:\n\n")
 			color.Green("  echo 'jwt = \"" + jwt + "\"' >> ~/.stormforger.toml")
 			color.Green("\n\n")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -30,10 +30,9 @@ Happy Load Testing :)`,
 	}
 
 	rootOpts struct {
-		APIEndpoint         string
-		JWT                 string
-		DefaultOrganisation string
-		OutputFormat        string
+		APIEndpoint  string
+		JWT          string
+		OutputFormat string
 	}
 )
 
@@ -102,18 +101,10 @@ func setupConfig() {
 	if err != nil {
 		log.Fatal(err)
 	}
-
-	err = viper.BindPFlag("defaults.organisation", RootCmd.PersistentFlags().Lookup("default-organisation"))
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	rootOpts.DefaultOrganisation = viper.GetString("defaults.organisation")
 }
 
 func init() {
 	RootCmd.PersistentFlags().StringVar(&rootOpts.APIEndpoint, "endpoint", "https://api.stormforger.com", "API Endpoint")
 	RootCmd.PersistentFlags().StringVar(&rootOpts.JWT, "jwt", "", "JWT access token")
-	RootCmd.PersistentFlags().StringVar(&rootOpts.DefaultOrganisation, "default-organisation", "", "Default organisation UID to use")
 	RootCmd.PersistentFlags().StringVar(&rootOpts.OutputFormat, "output", "human", "Output format: human,plain,json")
 }

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -31,12 +31,19 @@ func stringInSlice(a string, list []string) bool {
 // FindFixtureByName fetches a FileFixture from a given
 // organization.
 func findFixtureByName(client api.Client, organization string, name string) *filefixture.FileFixture {
-	fileFixtureListResponse, err := client.ListFileFixture(organization)
+	success, result, err := client.ListFileFixture(organization)
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	fileFixtures, err := filefixture.UnmarshalFileFixtures(bytes.NewReader(fileFixtureListResponse))
+	if !success {
+		fmt.Fprintln(os.Stderr, "Could not lookup data source!")
+		fmt.Fprintln(os.Stderr, string(result))
+
+		os.Exit(1)
+	}
+
+	fileFixtures, err := filefixture.Unmarshal(bytes.NewReader(result))
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
This PR will allow the usage of non-UID references to work with data sources.

The new pattern is now:

```console
$ forge datasource {get,ls,mv,push,rm,show} <organization-ref>
```

`<organization-ref>` can be the organiation name, `acme-inc` e.g. or the organisation's UID.

The flag `--default-organisation` has been removed without replacement.