### PR TITLE
add human/text output for test run watch command

### DIFF
--- a/api/testrun/main.go
+++ b/api/testrun/main.go
@@ -23,6 +23,10 @@ type TestRun struct {
 	StartedBy string `jsonapi:"attr,started_by,omitempty"`
 	StartedAt string `jsonapi:"attr,started_at,omitempty"`
 	EndedAt   string `jsonapi:"attr,ended_at,omitempty"`
+
+	// attributes for in progress
+	EstimatedEnd string `jsonapi:"attr,estimated_end,omitempty"`
+	Progress     int    `jsonapi:"attr,progress,omitempty"`
 }
 
 // NfrResultList is a list of NFR results

--- a/cmd/testcase_launch.go
+++ b/cmd/testcase_launch.go
@@ -81,7 +81,7 @@ func testRunLaunch(cmd *cobra.Command, args []string) {
 				log.Fatal(err)
 			}
 
-			watchTestRun(testRun.ID, testRunLaunchOpts.MaxWatchTime.Round(time.Second).Seconds())
+			watchTestRun(testRun.ID, testRunLaunchOpts.MaxWatchTime.Round(time.Second).Seconds(), rootOpts.OutputFormat)
 
 			result := fetchTestRun(*client, testRun.ID)
 			fmt.Println(string(result))

--- a/cmd/testrun_watch.go
+++ b/cmd/testrun_watch.go
@@ -56,10 +56,13 @@ func testRunWatch(cmd *cobra.Command, args []string) {
 
 	testRunUID := getTestRunUID(*client, args[0])
 
-	watchTestRun(testRunUID, testRunWatchOpts.MaxWatchTime.Round(time.Second).Seconds())
+	watchTestRun(testRunUID, testRunWatchOpts.MaxWatchTime.Round(time.Second).Seconds(), rootOpts.OutputFormat)
 
 	result := fetchTestRun(*client, testRunUID)
-	fmt.Println(string(result))
+
+	if rootOpts.OutputFormat == "json" {
+		fmt.Println(string(result))
+	}
 }
 
 func testRunOkay(testRun *testrun.TestRun) bool {


### PR DESCRIPTION
This PR adds `human` (or `text`) output format for `test-run watch` and `test-case launch … --watch` commands.

Currently the output is very simple:

```
$ forge tr watch acme-inc/shop/23
Test Run: 5ho1GO5y started now (est. end 1 minute from now)
[running] Progress: 1%
[running] Progress: 5%
[running] Progress: 9%
…
```

`--output=json` will result in the same output as before.