### PR TITLE
Add --nfr-check-file Option to Test Case Launch Command

### DIFF
--- a/cmd/testcase_launch.go
+++ b/cmd/testcase_launch.go
@@ -59,7 +59,7 @@ func init() {
 
 	testRunLaunchCmd.Flags().StringVarP(&testRunLaunchOpts.Title, "title", "t", "", "Descriptive title of test run")
 	testRunLaunchCmd.Flags().StringVarP(&testRunLaunchOpts.Notes, "notes", "n", "", "Longer description (Markdown supported)")
-	testRunLaunchCmd.Flags().StringVarP(&testRunLaunchOpts.CheckNFR, "nfr-check-file", "", "", "Check test result against NFR definition")
+	testRunLaunchCmd.Flags().StringVarP(&testRunLaunchOpts.CheckNFR, "nfr-check-file", "", "", "Check test result against NFR definition (implies --watch)")
 	testRunLaunchCmd.Flags().BoolVarP(&testRunLaunchOpts.Watch, "watch", "w", false, "Automatically watch newly launched test run")
 	testRunLaunchCmd.Flags().DurationVar(&testRunLaunchOpts.MaxWatchTime, "watch-timeout", 0, "Maximum duration in seconds to watch")
 }

--- a/cmd/testrun_nfr.go
+++ b/cmd/testrun_nfr.go
@@ -1,14 +1,9 @@
 package cmd
 
 import (
-	"bytes"
-	"fmt"
 	"log"
-	"os"
 
-	"github.com/fatih/color"
 	"github.com/spf13/cobra"
-	"github.com/stormforger/cli/api/testrun"
 )
 
 var (
@@ -43,71 +38,5 @@ func testRunNfrRun(cmd *cobra.Command, args []string) {
 		log.Fatal(err)
 	}
 
-	status, result, err := client.TestRunNfrCheck(testRunUID, fileName, file)
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	if rootOpts.OutputFormat == "json" {
-		fmt.Println(string(result))
-		return
-	}
-
-	if !status {
-		log.Fatalf("Could not perform test run NFR checks...\n%s", result)
-	}
-
-	items, err := testrun.UnmarshalNfrResults(bytes.NewReader(result))
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	green := color.New(color.FgGreen).SprintFunc()
-	red := color.New(color.FgRed).SprintFunc()
-	redBg := color.New(color.BgRed).Add(color.FgWhite).SprintFunc()
-	white := color.New(color.FgWhite).SprintFunc()
-
-	checkStatus := ""
-	anyFails := false
-	for _, item := range items.NfrResults {
-		if !item.Disabled {
-			actualSubject := ""
-			if item.Success {
-				checkStatus = green("\u2713")
-				actualSubject = fmt.Sprintf("was %s", item.SubjectWithUnit())
-			} else {
-				anyFails = true
-				checkStatus = red("\u2717")
-				actualSubject = fmt.Sprintf("but actually was %s", item.SubjectWithUnit())
-			}
-
-			filter := ""
-			if item.Filter != "null" && item.Filter != "" {
-				filter = " (where: " + item.Filter + ")"
-			}
-
-			fmt.Printf(
-				"%s %s expected to be %s; %s (%s)%s\n",
-				checkStatus,
-				item.Metric,
-				item.ExpectationWithUnit(),
-				actualSubject,
-				item.Type,
-				filter,
-			)
-		} else {
-			fmt.Printf(
-				"%s %s %s expected to be %s (%s)\n",
-				white("?"),
-				redBg("DISABLED"),
-				item.Metric,
-				item.ExpectationWithUnit(),
-				item.Type,
-			)
-		}
-	}
-
-	if anyFails {
-		os.Exit(1)
-	}
+	runNfrCheck(*client, testRunUID, fileName, file)
 }

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -133,6 +133,7 @@ func watchTestRun(testRunUID string, maxWatchTime float64, outputFormat string) 
 	started := time.Now()
 	first := true
 	testStarted := false
+	testEnded := false
 
 	for true {
 		runningSince := time.Now().Sub(started).Seconds()
@@ -192,8 +193,9 @@ func watchTestRun(testRunUID string, maxWatchTime float64, outputFormat string) 
 				}
 				fmt.Printf("[%s] Progress: %d%%\n", testRun.State, testRun.Progress)
 			default:
-				if testStarted {
+				if testStarted && !testEnded {
 					fmt.Printf("[status] Test run ended...\n")
+					testEnded = true
 				}
 
 				fmt.Printf("[%s]\n", testRun.State)


### PR DESCRIPTION
This PR adds a `--nfr-check-file` option to `forge test-case launch` command.

Example:

```console
$ forge test-case launch acme-inc/shop --nfr-check-file=nfr/blackfriday.yml
```

This is basically the same as

```console
$ forge test-case launch acme-inc/shop --watch
```

followed by

```console
$ forge test-run nfr acme-inc/shop/42 nfr/blackfriday.yml
```

When using the `--nfr-check-file` option, the output will look something like this:

```console
[status] Test Run: dZ10eSWt started not yet (est. end n/a)
[deploying]
[status] Test Run: dZ10eSWt started 1 second ago (est. end 58 seconds from now)
[running] Progress: 3%
…
[status] Test run ended...
[analysing]
[status] Test run ended...
[done]
Test finished, running non-functional checks...
✓ test completion expected to be == true; was true (test.completed)
✓ 99.0th percentile request latency expected to be <= 9000 ms; was 88 ms (http.latency)

All checks passed!
```