### PR TITLE
Data Sources: Add --auto-field-names

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ You can...
 * `--name`: Name of the new data source. If not provided it will be inferred from the uploaded file name (optional)
 * `--name-prefix-path`: Path prefix for new data sources (optional)
 * `--raw`: Upload file as is (optional, default: false)
+* `--auto-field-names`: Interpret first row as headers and use them as field names
 
 
 ## Build

--- a/api/file_fixture.go
+++ b/api/file_fixture.go
@@ -8,10 +8,11 @@ import (
 
 // FileFixtureParams represents params BLA TODO
 type FileFixtureParams struct {
-	Name       string
-	Type       string
-	FieldNames string
-	Delimiter  string
+	Name            string
+	Type            string
+	FieldNames      string
+	Delimiter       string
+	FirstRowHeaders bool
 }
 
 // MoveFileFixture renames a filefixtures
@@ -56,6 +57,10 @@ func (c *Client) PushFileFixture(fileName string, data io.Reader, organization s
 	extraParams := map[string]string{
 		"file_fixture[name]": params.Name,
 		"file_fixture[type]": params.Type,
+	}
+
+	if params.FirstRowHeaders {
+		extraParams["file_fixture[file_fixture_version][first_row_headers]"] = "1"
 	}
 
 	if params.Delimiter != "" {

--- a/cmd/datasource_push.go
+++ b/cmd/datasource_push.go
@@ -57,13 +57,17 @@ var (
 func init() {
 	datasourceCmd.AddCommand(datasourcePushCmd)
 
+	// type of FF
 	datasourcePushCmd.Flags().BoolVarP(&pushOpts.Raw, "raw", "r", false, "Upload file as raw fixture")
-	datasourcePushCmd.Flags().BoolVarP(&pushOpts.FirstRowHeaders, "auto-field-names", "", false, "Interpret first row as headers")
 
-	datasourcePushCmd.Flags().StringVarP(&pushOpts.Delimiter, "delimiter", "d", "", "Column Delimiter")
+	// general options
 	datasourcePushCmd.Flags().StringVarP(&pushOpts.Name, "name", "n", "", "Name for the file fixture")
 	datasourcePushCmd.Flags().StringVarP(&pushOpts.NamePrefixPath, "name-prefix-path", "p", "", "Prefix for name for the file fixture")
-	datasourcePushCmd.Flags().StringVarP(&pushOpts.FieldNames, "fields", "f", "", "Name for the fields/columns, comma separated")
+
+	// options for structured FF
+	datasourcePushCmd.Flags().StringVarP(&pushOpts.Delimiter, "delimiter", "d", "", "Column Delimiter")
+	datasourcePushCmd.Flags().StringVarP(&pushOpts.FieldNames, "fields", "f", "", "Name for the fields/columns, comma separated (,)")
+	datasourcePushCmd.Flags().BoolVarP(&pushOpts.FirstRowHeaders, "auto-field-names", "", false, "Interpret first row as headers")
 }
 
 func runDataSourcePush(cmd *cobra.Command, args []string) {

--- a/cmd/datasource_push.go
+++ b/cmd/datasource_push.go
@@ -20,6 +20,10 @@ var (
 				log.Fatal("Expecting one or more arguments: File(s) to upload")
 			}
 
+			if pushOpts.Raw && (pushOpts.FieldNames != "" || pushOpts.Delimiter != "" || pushOpts.FirstRowHeaders) {
+				log.Fatal("Raw file fixtures do not support --fields, --delimiter and --auto-field-names")
+			}
+
 			if len(args) > 2 && (pushOpts.Name != "" || pushOpts.FieldNames != "") {
 				log.Fatal("--name and --fields is not supported for multiple uploads")
 			}

--- a/cmd/datasource_push.go
+++ b/cmd/datasource_push.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"os"
 	"path"
+	"unicode/utf8"
 
 	"github.com/spf13/cobra"
 	"github.com/stormforger/cli/api"
@@ -30,6 +31,10 @@ var (
 
 			if pushOpts.Name != "" && pushOpts.FirstRowHeaders {
 				log.Fatal("--name and --auto-field-names are mutual exclusive")
+			}
+
+			if pushOpts.Delimiter != "" && utf8.RuneCountInString(pushOpts.Delimiter) > 1 {
+				log.Fatal("Delimiter can only be one character!")
 			}
 
 			datasourceOpts.Organisation = lookupOrganisationUID(*NewClient(), args[0])


### PR DESCRIPTION
This PR adds `--auto-field-names` to `forge datasource push` command.

It will tell the API to interpret the first row as header names. This is mutually exclusive with the `--name` option, but can be used when multiple files should be uploaded (unlike `--name`).

Also, this PR improves checking of `datasource push` command options:

* `--delimiter` must be exactly one character
* `--fields`, `--delimiter` and `--auto-field-names` cannot be used with `--raw`