### PR TITLE
--fields and --auto-field-names are mutual exclusive

### DIFF
--- a/cmd/datasource_push.go
+++ b/cmd/datasource_push.go
@@ -118,7 +118,7 @@ func runDataSourcePush(cmd *cobra.Command, args []string) {
 		}
 
 		if !success {
-			fmt.Fprintln(os.Stderr, "Could not upload files as new data source!")
+			fmt.Fprintln(os.Stderr, "Could not create or update files as data sources!")
 			fmt.Fprintln(os.Stderr, string(result))
 
 			os.Exit(1)

--- a/cmd/datasource_push.go
+++ b/cmd/datasource_push.go
@@ -29,8 +29,8 @@ var (
 				log.Fatal("--name and --fields is not supported for multiple uploads")
 			}
 
-			if pushOpts.Name != "" && pushOpts.FirstRowHeaders {
-				log.Fatal("--name and --auto-field-names are mutual exclusive")
+			if pushOpts.FieldNames != "" && pushOpts.FirstRowHeaders {
+				log.Fatal("--fields and --auto-field-names are mutual exclusive")
 			}
 
 			if pushOpts.Delimiter != "" && utf8.RuneCountInString(pushOpts.Delimiter) > 1 {


### PR DESCRIPTION
We recently introduced automatic field name extraction for `datasource` in #47. But we discovered making the `--name` and `--auto-field-names` option mutual exclusive isn't helpful. Assigning a name to a datasource makes still sense even if we assign the field name automatically. We just can't use `--name` when pushing multiple files at once. This was already checked.

On the other hand manually assigning field names with `--fields` doesn't work well together with an automatic extraction. This PR now has `--fields` and `--auto-field-names` mutual exclusive.