### PR TITLE
Test Case/Run: add --archived option

### DIFF
--- a/api/testcase.go
+++ b/api/testcase.go
@@ -6,8 +6,15 @@ import (
 )
 
 // ListTestCases returns a list of test cases
-func (c *Client) ListTestCases(organization string) (bool, []byte, error) {
+func (c *Client) ListTestCases(organization string, filter string) (bool, []byte, error) {
 	path := "/organisations/" + organization + "/test_cases"
+
+	switch filter {
+	case "archived":
+		path = path + "/?only=archived"
+	case "all":
+		path = path + "/?only=all"
+	}
 
 	return c.fetch(path)
 }

--- a/api/testrun.go
+++ b/api/testrun.go
@@ -34,8 +34,15 @@ type TestRunResources struct {
 }
 
 // TestRunList will list all test runs for a given test case
-func (c *Client) TestRunList(testCaseUID string) (bool, []byte, error) {
+func (c *Client) TestRunList(testCaseUID string, filter string) (bool, []byte, error) {
 	path := "/test_cases/" + testCaseUID + "/test_runs"
+
+	switch filter {
+	case "archived":
+		path = path + "/?only=archived"
+	case "all":
+		path = path + "/?only=all"
+	}
 
 	status, response, err := c.fetch(path)
 

--- a/cmd/testcase_list.go
+++ b/cmd/testcase_list.go
@@ -35,17 +35,25 @@ var (
 
 	testCaseListOpts struct {
 		Organisation string
+		Archived     bool
 	}
 )
 
 func init() {
 	TestCaseCmd.AddCommand(testCaseListCmd)
+
+	testCaseListCmd.Flags().BoolVarP(&testCaseListOpts.Archived, "archived", "", false, "List archived test cases")
 }
 
 func runTestCaseList(cmd *cobra.Command, args []string) {
 	client := NewClient()
 
-	status, result, err := client.ListTestCases(testCaseListOpts.Organisation)
+	filter := ""
+	if testCaseListOpts.Archived {
+		filter = "archived"
+	}
+
+	status, result, err := client.ListTestCases(testCaseListOpts.Organisation, filter)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/testrun_list.go
+++ b/cmd/testrun_list.go
@@ -34,10 +34,16 @@ var (
 			}
 		},
 	}
+
+	testRunListOpts struct {
+		Archived bool
+	}
 )
 
 func init() {
 	TestRunCmd.AddCommand(testRunListCmd)
+
+	testRunListCmd.Flags().BoolVarP(&testRunListOpts.Archived, "archived", "", false, "List archived test runs")
 }
 
 func testRunList(cmd *cobra.Command, args []string) {
@@ -45,7 +51,12 @@ func testRunList(cmd *cobra.Command, args []string) {
 
 	testCaseUID := lookupTestCase(*client, args[0])
 
-	status, result, err := client.TestRunList(testCaseUID)
+	filter := ""
+	if testRunListOpts.Archived {
+		filter = "archived"
+	}
+
+	status, result, err := client.TestRunList(testCaseUID, filter)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -248,7 +248,7 @@ func lookupTestCase(client api.Client, input string) string {
 
 		organisationUID := lookupOrganisationUID(client, organisationNameOrUID)
 
-		_, result, err := client.ListTestCases(organisationUID)
+		_, result, err := client.ListTestCases(organisationUID, "all")
 		if err != nil {
 			log.Fatal(err)
 		}


### PR DESCRIPTION
`--archived` will only list test runs or cases that have been archived.

Now, by default, **only archived** test runs or cases will be listed.