### PR TITLE
Add Test Configuration Info to outputs

### DIFF
--- a/api/meta.go
+++ b/api/meta.go
@@ -1,0 +1,30 @@
+package api
+
+import (
+	"encoding/json"
+	"io"
+)
+
+type Meta struct {
+	Links *Links `json:"links"`
+}
+
+// Links holds JSONAPI links
+type Links struct {
+	Self     string `json:"self"`
+	SelfWeb  string `json:"self_web"`
+	TestCase string `json:"test_case"`
+}
+
+func UnmarshalMeta(input io.Reader) (Meta, error) {
+	type foo struct {
+		Meta *Meta `json:"data"`
+	}
+
+	var data foo
+	if err := json.NewDecoder(input).Decode(&data); err != nil {
+		return Meta{}, err
+	}
+
+	return *data.Meta, nil
+}

--- a/api/testrun/main.go
+++ b/api/testrun/main.go
@@ -15,18 +15,30 @@ type List struct {
 
 // TestRun represents a single TestRun
 type TestRun struct {
-	ID        string `jsonapi:"primary,test_runs"`
-	Scope     string `jsonapi:"attr,scope"`
-	Title     string `jsonapi:"attr,title,omitempty"`
-	Notes     string `jsonapi:"attr,notes,omitempty"`
-	State     string `jsonapi:"attr,state,omitempty"`
-	StartedBy string `jsonapi:"attr,started_by,omitempty"`
-	StartedAt string `jsonapi:"attr,started_at,omitempty"`
-	EndedAt   string `jsonapi:"attr,ended_at,omitempty"`
+	ID                string             `jsonapi:"primary,test_runs"`
+	Scope             string             `jsonapi:"attr,scope"`
+	Title             string             `jsonapi:"attr,title,omitempty"`
+	Notes             string             `jsonapi:"attr,notes,omitempty"`
+	State             string             `jsonapi:"attr,state,omitempty"`
+	StartedBy         string             `jsonapi:"attr,started_by,omitempty"`
+	StartedAt         string             `jsonapi:"attr,started_at,omitempty"`
+	EndedAt           string             `jsonapi:"attr,ended_at,omitempty"`
+	TestConfiguration *TestConfiguration `jsonapi:"relation,test_configuration,omitempty"`
 
 	// attributes for in progress
 	EstimatedEnd string `jsonapi:"attr,estimated_end,omitempty"`
 	Progress     int    `jsonapi:"attr,progress,omitempty"`
+}
+
+// TestConfiguration contains configuration options for the test case
+type TestConfiguration struct {
+	ID                    string `jsonapi:"primary,test_configurations"`
+	DisableGzip           bool   `jsonapi:"attr,disable_gzip"`
+	SkipWait              bool   `jsonapi:"attr,skip_wait"`
+	DumpTrafficFull       bool   `jsonapi:"attr,dump_traffic_full"`
+	SessionValidationMode bool   `jsonapi:"attr,session_validation_mode"`
+	ClusterSizing         string `jsonapi:"attr,cluster_sizing"`
+	ClusterRegion         string `jsonapi:"attr,cluster_region"`
 }
 
 // NfrResultList is a list of NFR results
@@ -69,15 +81,11 @@ func Unmarshal(input io.Reader) (List, error) {
 	return result, nil
 }
 
-// UnmarshalSingle unmarshals a single TestRun records
+// UnmarshalSingle unmarshals a single test run record
 func UnmarshalSingle(input io.Reader) (TestRun, error) {
 	item := new(TestRun)
 	err := jsonapi.UnmarshalPayload(input, item)
-	if err != nil {
-		return TestRun{}, err
-	}
-
-	return *item, nil
+	return *item, err
 }
 
 // UnmarshalNfrResults unmarshals a list of NFR result records

--- a/cmd/testrun_show.go
+++ b/cmd/testrun_show.go
@@ -6,6 +6,7 @@ import (
 	"log"
 
 	"github.com/spf13/cobra"
+	"github.com/stormforger/cli/api"
 	"github.com/stormforger/cli/api/testrun"
 )
 
@@ -49,13 +50,36 @@ func testRunShow(cmd *cobra.Command, args []string) {
 		log.Fatal(err)
 	}
 
+	// FIXME can we integrate this into testrun.UnmarshalSingle somehow?
+	meta, err := api.UnmarshalMeta(bytes.NewReader(result))
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	fmt.Printf("%s (%s, %s)\n", testRun.Scope, testRun.State, testRun.ID)
+	fmt.Printf("Report  %s\n", meta.Links.SelfWeb)
 	if testRun.Title != "" {
 		fmt.Printf("Title   %s\n", testRun.Title)
 	}
 	fmt.Printf("Started %s\n", testRun.StartedAt)
 	fmt.Printf("Ended   %s\n", testRun.EndedAt)
+	fmt.Print("Configuration:\n")
+	fmt.Printf("  Setup: %s cluster in %s\n", testRun.TestConfiguration.ClusterSizing, testRun.TestConfiguration.ClusterRegion)
+
+	if testRun.TestConfiguration.DisableGzip {
+		fmt.Print("  [\u2713] Disabled GZIP\n")
+	}
+	if testRun.TestConfiguration.SkipWait {
+		fmt.Print("  [\u2713] Skip Waits\n")
+	}
+	if testRun.TestConfiguration.DumpTrafficFull {
+		fmt.Print("  [\u2713] Traffic Dump\n")
+	}
+	if testRun.TestConfiguration.SessionValidationMode {
+		fmt.Print("  [\u2713] Session Validation Mode\n")
+	}
+
 	if testRun.Notes != "" {
-		fmt.Printf("%s\n", testRun.Notes)
+		fmt.Printf("\nNotes:\n%s\n", testRun.Notes)
 	}
 }


### PR DESCRIPTION
This PR will print test run configuration options to various commands:

* `test-run show` will now print information on region, sizing and advanced options
* `test-case launch` will now also print these infos

In addition to that, we now unmarshal some meta data (links to be specific) to print "human" URLs to access reports etc.

Also, `--output=json` was improved for launching test runs.