### PR TITLE
Test Case: Add include magic comment

### DIFF
--- a/cmd/testcase_create.go
+++ b/cmd/testcase_create.go
@@ -74,7 +74,7 @@ func init() {
 func runTestCaseCreate(cmd *cobra.Command, args []string) {
 	organizationUID := testCaseCreateOpts.Organisation
 
-	fileName, testCaseFile, err := readFromStdinOrReadFromArgument(args, "test_case.js", 1)
+	fileName, testCaseFile, err := readTestCaseFromStdinOrReadFromArgument(args, "test_case.js", 1)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/testcase_update.go
+++ b/cmd/testcase_update.go
@@ -52,7 +52,7 @@ func runTestCaseUpdate(cmd *cobra.Command, args []string) {
 
 	testCaseUID := lookupTestCase(*client, args[0])
 
-	fileName, testCaseFile, err := readFromStdinOrReadFromArgument(args, "test_case.js", 1)
+	fileName, testCaseFile, err := readTestCaseFromStdinOrReadFromArgument(args, "test_case.js", 1)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/testcase_validate.go
+++ b/cmd/testcase_validate.go
@@ -59,7 +59,7 @@ func init() {
 }
 
 func runTestCaseValidate(cmd *cobra.Command, args []string) {
-	fileName, testCaseFile, err := readFromStdinOrReadFromArgument(args, "test_case.js", 1)
+	fileName, testCaseFile, err := readTestCaseFromStdinOrReadFromArgument(args, "test_case.js", 1)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/testdata/cases/includes/base.js
+++ b/testdata/cases/includes/base.js
@@ -1,0 +1,22 @@
+definition.setTarget("testapp.loadtest.party");
+
+definition.setArrivalPhases([{
+    duration: 5 * 60,
+    rate: 50,
+    max_users: 2000
+  },
+  {
+    duration: 15 * 60,
+    rate: 60,
+    max_users: 5000
+  },
+]);
+
+
+//#include ./session_base.js
+
+//#include /Users/basti/Documents/src/golang/src/github.com/stormforger/cli/testdata/cases/includes/helpers.js
+
+function otherHelpers() {
+  // ...
+}

--- a/testdata/cases/includes/helpers.js
+++ b/testdata/cases/includes/helpers.js
@@ -1,0 +1,7 @@
+function helper1() {
+  // ...
+}
+
+function helper2() {
+  // ...
+}

--- a/testdata/cases/includes/session_base.js
+++ b/testdata/cases/includes/session_base.js
@@ -1,0 +1,14 @@
+definition.session("base", function (session) {
+  session.get("/users/configuration", {
+    gzip: true,
+    tag: "user_configuration",
+    headers: {
+      "Accept": "application/json",
+      "X-DemoApp-Token": session.matchedValue("authenticationToken"),
+    },
+  });
+
+  session.wait(2, {
+    random: true
+  });
+});


### PR DESCRIPTION
With this PR you can now do simple client-side includes. This is a prototype and has to be seen as a first approach to make test cases more modular.

Given a test case like this:

```js
definition.setTarget("testapp.loadtest.party");

definition.setArrivalPhases([{
    duration: 5 * 60,
    rate: 50,
    max_users: 2000
  },
]);

//#include ./session_base.js

//#include /Users/basti/Documents/src/golang/src/github.com/stormforger/cli/testdata/cases/includes/helpers.js

function otherHelpers() {
  // ...
}
```

using `test-case update` or `test-case create` commands, will yield in a case like this:

```js
definition.setTarget("testapp.loadtest.party");

definition.setArrivalPhases([{
    duration: 5 * 60,
    rate: 50,
    max_users: 2000
  },
]);


// == start include (testdata/cases/includes/session_base.js)
definition.session("base", function (session) {
  session.get("/users/configuration", {
    gzip: true,
    tag: "user_configuration",
    headers: {
      "Accept": "application/json",
      "X-DemoApp-Token": session.matchedValue("authenticationToken"),
    },
  });

  session.wait(2, {
    random: true
  });
});
// == end include (testdata/cases/includes/session_base.js)

// == start include (/Users/basti/Documents/src/golang/src/github.com/stormforger/cli/testdata/cases/includes/helpers.js)
function helper1() {
  // ...
}

function helper2() {
  // ...
}
// == end include (/Users/basti/Documents/src/golang/src/github.com/stormforger/cli/testdata/cases/includes/helpers.js)

function otherHelpers() {
  // ...
}
```