### PR TITLE
*: Organization -> Organisation

### DIFF
--- a/cmd/datasource.go
+++ b/cmd/datasource.go
@@ -17,5 +17,5 @@ var (
 func init() {
 	RootCmd.AddCommand(datasourceCmd)
 
-	datasourceCmd.PersistentFlags().StringVarP(&datasourceOpts.Organisation, "organization", "o", "", "Name of the organization")
+	datasourceCmd.PersistentFlags().StringVarP(&datasourceOpts.Organisation, "organisation", "o", "", "Name of the organisation")
 }

--- a/cmd/datasource_delete.go
+++ b/cmd/datasource_delete.go
@@ -8,7 +8,7 @@ import (
 
 var (
 	datasourceDeleteCmd = &cobra.Command{
-		Use:     "rm <organization-ref> <name>",
+		Use:     "rm <organisation-ref> <name>",
 		Aliases: []string{"delete", "remove"},
 		Short:   "Delete a fixture",
 		Run:     runDatasourceDelete,
@@ -18,12 +18,12 @@ var (
 			}
 
 			if len(args) < 1 {
-				log.Fatal("Missing organization")
+				log.Fatal("Missing organisation")
 			}
 
 			datasourceOpts.Organisation = lookupOrganisationUID(*NewClient(), args[0])
 			if datasourceOpts.Organisation == "" {
-				log.Fatal("Missing organization")
+				log.Fatal("Missing organisation")
 			}
 		},
 	}

--- a/cmd/datasource_download.go
+++ b/cmd/datasource_download.go
@@ -11,7 +11,7 @@ import (
 
 var (
 	datasourceDownloadCmd = &cobra.Command{
-		Use:     "get <organization-ref> <name>",
+		Use:     "get <organisation-ref> <name>",
 		Aliases: []string{"download"},
 		Short:   "Download file fixture",
 		Run:     runDatasourceDownload,
@@ -21,12 +21,12 @@ var (
 			}
 
 			if len(args) < 1 {
-				log.Fatal("Missing organization")
+				log.Fatal("Missing organisation")
 			}
 
 			datasourceOpts.Organisation = lookupOrganisationUID(*NewClient(), args[0])
 			if datasourceOpts.Organisation == "" {
-				log.Fatal("Missing organization")
+				log.Fatal("Missing organisation")
 			}
 		},
 	}

--- a/cmd/datasource_list.go
+++ b/cmd/datasource_list.go
@@ -12,7 +12,7 @@ import (
 
 var (
 	datasourceListCmd = &cobra.Command{
-		Use:     "ls <organization-ref>",
+		Use:     "ls <organisation-ref>",
 		Aliases: []string{"list"},
 		Short:   "List fixtures",
 		Run:     runDataSourceList,
@@ -22,12 +22,12 @@ var (
 			}
 
 			if len(args) < 1 {
-				log.Fatal("Missing organization")
+				log.Fatal("Missing organisation")
 			}
 
 			datasourceOpts.Organisation = lookupOrganisationUID(*NewClient(), args[0])
 			if datasourceOpts.Organisation == "" {
-				log.Fatal("Missing organization")
+				log.Fatal("Missing organisation")
 			}
 		},
 	}

--- a/cmd/datasource_move.go
+++ b/cmd/datasource_move.go
@@ -10,7 +10,7 @@ import (
 
 var (
 	datasourceMoveCmd = &cobra.Command{
-		Use:     "mv <organization-ref> <name> <new-name>",
+		Use:     "mv <organisation-ref> <name> <new-name>",
 		Aliases: []string{"move", "rename"},
 		Short:   "Rename a fixture",
 		Run:     runDataSourceMove,
@@ -21,7 +21,7 @@ var (
 
 			datasourceOpts.Organisation = lookupOrganisationUID(*NewClient(), args[0])
 			if datasourceOpts.Organisation == "" {
-				log.Fatal("Missing organization")
+				log.Fatal("Missing organisation")
 			}
 		},
 	}

--- a/cmd/datasource_push.go
+++ b/cmd/datasource_push.go
@@ -17,12 +17,12 @@ import (
 
 var (
 	datasourcePushCmd = &cobra.Command{
-		Use:   "push <organization-ref> <file>",
+		Use:   "push <organisation-ref> <file>",
 		Short: "Upload a file",
 		Run:   runDataSourcePush,
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
 			if len(args) < 2 {
-				log.Fatal("Expecting one or more arguments: File(s) to upload")
+				log.Fatal("Expecting one or more arguments: organisation and file(s) to upload")
 			}
 
 			if pushOpts.Raw && (pushOpts.FieldNames != "" || pushOpts.Delimiter != "" || pushOpts.FirstRowHeaders) {
@@ -43,7 +43,7 @@ var (
 
 			datasourceOpts.Organisation = lookupOrganisationUID(*NewClient(), args[0])
 			if datasourceOpts.Organisation == "" {
-				log.Fatal("Missing organization")
+				log.Fatal("Missing organisation")
 			}
 		},
 	}

--- a/cmd/datasource_show.go
+++ b/cmd/datasource_show.go
@@ -9,7 +9,7 @@ import (
 
 var (
 	datasourceShowCmd = &cobra.Command{
-		Use:     "show <organization-ref> <name>",
+		Use:     "show <organisation-ref> <name>",
 		Aliases: []string{},
 		Short:   "Show details of fixture",
 		Run:     runDatasourceShow,
@@ -19,12 +19,12 @@ var (
 			}
 
 			if len(args) < 1 {
-				log.Fatal("Missing organization")
+				log.Fatal("Missing organisation")
 			}
 
 			datasourceOpts.Organisation = lookupOrganisationUID(*NewClient(), args[0])
 			if datasourceOpts.Organisation == "" {
-				log.Fatal("Missing organization")
+				log.Fatal("Missing organisation")
 			}
 		},
 	}

--- a/cmd/testcase_create.go
+++ b/cmd/testcase_create.go
@@ -49,7 +49,7 @@ Examples
 
 			testCaseCreateOpts.Organisation = lookupOrganisationUID(*NewClient(), segments[0])
 			if testCaseCreateOpts.Organisation == "" {
-				log.Fatal("Missing organization")
+				log.Fatal("Missing organisation")
 			}
 
 			testCaseCreateOpts.Name = segments[1]
@@ -72,7 +72,7 @@ func init() {
 }
 
 func runTestCaseCreate(cmd *cobra.Command, args []string) {
-	organizationUID := testCaseCreateOpts.Organisation
+	orgaUID := testCaseCreateOpts.Organisation
 
 	fileName, testCaseFile, err := readTestCaseFromStdinOrReadFromArgument(args, "test_case.js", 1)
 	if err != nil {
@@ -93,7 +93,7 @@ func runTestCaseCreate(cmd *cobra.Command, args []string) {
 
 	client := NewClient()
 
-	success, message, errValidation := client.TestCaseCreate(organizationUID, testCaseName, fileName, testCaseFile)
+	success, message, errValidation := client.TestCaseCreate(orgaUID, testCaseName, fileName, testCaseFile)
 	if errValidation != nil {
 		log.Fatal(errValidation)
 	}

--- a/cmd/testcase_list.go
+++ b/cmd/testcase_list.go
@@ -13,9 +13,9 @@ import (
 var (
 	// testCaseListCmd represents the testCaseValidate command
 	testCaseListCmd = &cobra.Command{
-		Use:     "list <organization-ref>",
+		Use:     "list <organisation-ref>",
 		Aliases: []string{"ls"},
-		Short:   "List test case for a given organization",
+		Short:   "List test case for a given organisation",
 		Run:     runTestCaseList,
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
 			if len(args) > 1 {
@@ -23,12 +23,12 @@ var (
 			}
 
 			if len(args) < 1 {
-				log.Fatal("Missing organization")
+				log.Fatal("Missing organisation")
 			}
 
 			testCaseListOpts.Organisation = lookupOrganisationUID(*NewClient(), args[0])
 			if testCaseListOpts.Organisation == "" {
-				log.Fatal("Missing organization")
+				log.Fatal("Missing organisation")
 			}
 		},
 	}

--- a/cmd/testcase_validate.go
+++ b/cmd/testcase_validate.go
@@ -41,12 +41,12 @@ Examples
 			}
 
 			if len(args) < 2 {
-				log.Fatal("Missing arguments; organization reference and test case file to validate (or - to read from stdin)")
+				log.Fatal("Missing arguments; organisation reference and test case file to validate (or - to read from stdin)")
 			}
 
 			testCaseValidateOpts.Organisation = lookupOrganisationUID(*NewClient(), args[0])
 			if testCaseValidateOpts.Organisation == "" {
-				log.Fatal("Missing organization")
+				log.Fatal("Missing organisation")
 			}
 		},
 	}

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -32,10 +32,9 @@ func stringInSlice(a string, list []string) bool {
 	return false
 }
 
-// FindFixtureByName fetches a FileFixture from a given
-// organization.
-func findFixtureByName(client api.Client, organization string, name string) *filefixture.FileFixture {
-	success, result, err := client.ListFileFixture(organization)
+// FindFixtureByName fetches a FileFixture from a given Organisation.
+func findFixtureByName(client api.Client, orga string, name string) *filefixture.FileFixture {
+	success, result, err := client.ListFileFixture(orga)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -54,14 +53,13 @@ func findFixtureByName(client api.Client, organization string, name string) *fil
 
 	fileFixture := fileFixtures.FindByName(name)
 	if fileFixture.ID == "" {
-		log.Fatalf("Data source %s not found in organization %s!", name, organization)
+		log.Fatalf("Data source %s not found in organisation %s!", name, orga)
 	}
 
 	return &fileFixture
 }
 
-// findOrganisationByName fetches a FileFixture from a given
-// organization.
+// findOrganisationByName fetches a FileFixture from a given Organisation.
 func findOrganisationByName(client api.Client, name string) *organisation.Organisation {
 	status, response, err := client.ListOrganisations()
 	if err != nil {


### PR DESCRIPTION
* Renamed all user visible strings to organisation (from organization). 
* Code strings have been shortened to `orga` (in the `cmd/` package)

This was based on the default Use in `organisation.go`. We can also rename this the other way around, as the API seem to provide the `/organization` route.