### PR TITLE
docker: Add forge user so we don't run as root. #61

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,12 @@
 FROM ubuntu:18.04
 
+ENV DEBIAN_FRONTEND=noninteractive
+
 COPY forge /bin
 
 RUN apt-get -y update && apt-get -y install ca-certificates
+RUN useradd -ms /bin/bash forge
+USER forge
+WORKDIR /home/forge
 
 ENTRYPOINT [ "forge" ]


### PR DESCRIPTION
Fixes #61.

I also set the debian frontend to noninteractive which makes the docker build output a lot shorter and less noisy.