### PR TITLE
Add Gzip compression for all file uploads

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -92,7 +92,7 @@ type Client struct {
 }
 
 // NewClient returns a new initialized API client
-func NewClient(apiEndpoint string, jwtToken string) *Client {
+func NewClient(apiEndpoint, jwtToken string) *Client {
 	return &Client{
 		HTTPClient:  defaultHTTPClient(),
 		APIEndpoint: apiEndpoint,
@@ -130,7 +130,7 @@ func newPatchRequest(uri string, params map[string]string) (*http.Request, error
 	return req, err
 }
 
-func createFormFile(w *multipart.Writer, fieldname string, filename string, contenttype string) (io.Writer, error) {
+func createFormFile(w *multipart.Writer, fieldname, filename, contenttype string) (io.Writer, error) {
 	replacer := strings.NewReplacer("\\", "\\\\", `"`, "\\\"")
 
 	h := make(textproto.MIMEHeader)
@@ -142,7 +142,7 @@ func createFormFile(w *multipart.Writer, fieldname string, filename string, cont
 	return w.CreatePart(h)
 }
 
-func fileUploadRequest(uri string, method string, params map[string]string, paramName string, fileName string, mimeType string, data io.Reader) (*http.Request, error) {
+func fileUploadRequest(uri, method string, params map[string]string, paramName, fileName, mimeType string, data io.Reader) (*http.Request, error) {
 	body := &bytes.Buffer{}
 	writer := multipart.NewWriter(body)
 	part, err := createFormFile(writer, paramName, fileName, mimeType)
@@ -189,7 +189,7 @@ func (c *Client) doRequestRaw(request *http.Request) (*http.Response, error) {
 }
 
 // LookupAndFetchResource tries to download a given resource from the API
-func (c *Client) LookupAndFetchResource(resourceType string, input string) (bool, []byte, error) {
+func (c *Client) LookupAndFetchResource(resourceType, input string) (bool, []byte, error) {
 	return c.FetchResource("/lookup?type=" + resourceType + "&q=" + input)
 }
 

--- a/api/har.go
+++ b/api/har.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -22,7 +23,7 @@ func (c *Client) Har(fileName string, data io.Reader) (string, error) {
 		return "", fmt.Errorf("given HAR is not valid JSON")
 	}
 
-	req, err := fileUploadRequest(c.APIEndpoint+"/har", "POST", extraParams, "har_file", fileName, "application/octet-stream", data)
+	req, err := fileUploadRequest(c.APIEndpoint+"/har", "POST", extraParams, "har_file", fileName, "application/octet-stream", bytes.NewReader(input))
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/api/har.go
+++ b/api/har.go
@@ -1,8 +1,6 @@
 package api
 
 import (
-	"bytes"
-	"compress/gzip"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -24,12 +22,7 @@ func (c *Client) Har(fileName string, data io.Reader) (string, error) {
 		return "", fmt.Errorf("given HAR is not valid JSON")
 	}
 
-	var buf bytes.Buffer
-	harFileGzip := gzip.NewWriter(&buf)
-	io.Copy(harFileGzip, bytes.NewReader(input))
-	harFileGzip.Close()
-
-	req, err := fileUploadRequest(c.APIEndpoint+"/har", "POST", extraParams, "har_file", fileName, "application/gzip", bytes.NewReader(buf.Bytes()))
+	req, err := fileUploadRequest(c.APIEndpoint+"/har", "POST", extraParams, "har_file", fileName, "application/octet-stream", data)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/testcase_create.go
+++ b/cmd/testcase_create.go
@@ -19,14 +19,15 @@ var (
 		Long: `Create a new test case.
 
 <test-case-ref> is 'organisation-name/test-case-name'.
+<test-case-file> is a path or - for stdin.
 
 Examples
 --------
-* create a new test case named 'checkout' in the 'acme-inc' organisation
+* Create a new test case named 'checkout' in the 'acme-inc' organisation
 
   forge test-case create acme-inc/checkout cases/checkout_process.js
 
-* alternatively the test definition can be piped in as well
+* Alternatively the test definition can be piped in as well
 
   cat cases/checkout_process.js | forge test-case create acme-inc/checkout -
 


### PR DESCRIPTION
## Change
This PR changes the behavior of `fileUploadRequest` to perform gzip compression on all files uploaded to the Stormforger API and upload it with an additional `content-encoding: gzip` header.
Additionally it reverts the HAR upload compression, as this is no longer needed.

## User Benefit
This benefits users who upload large file fixtures or test cases.

## Caveats
Currently the API does not yet support this feature, as it is not a usual thing browser do. We have to support this by hand on the server side. 