### PR TITLE
Fix test-case update exit code for validation errors and validation output formatting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # build artifacts
 forge
+cli
 build/
 dist/
 


### PR DESCRIPTION
## Changes
* Test-case update now throws an exit=1 when the update itself fails
* Output is prefixed with INFO/WARN/ERROR based on command result
* Exit Code represents whether the tc was updated or not, not whether there was a validation error or not

## Examples

```
# This had an exitcode=0 before
$ ./forge test-case update zeisss ./demo.js
ERROR: Test case unknown
exit status 1


# No Validation Errors
$ ./forge test-case update foo/demo ./demo.js
INFO: Test case updated

# Validation Errors
$ ./forge test-case update foo/demo ./demo.js
WARN: Test case updated, but contains issues which have to be addressed

1) E0: Invalid Attribute
Instance type 'c5.xlarge' is not available!

2) E0: Invalid Attribute
Maximum allowed c5.large instances is 11 instances

# Update Errors
$ ./forge test-case update foo/demo ./demo.js
ERROR: Test case could not be updated

1) E23: Evaluation Error
ReferenceError: afasd is not defined
    at demo.js:1:12

exit status 1
```
