### PR TITLE
goreleaser: Update brew step to plural due to deprecation of old variant (fixes #77)

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -3,14 +3,14 @@ release:
   github:
     owner: stormforger
     name: cli
-brew:
-  github:
-    owner: stormforger
-    name: homebrew-forge
-  install: bin.install "forge"
-  folder: Formula
-  homepage: "https://stormforger.com"
-  description: "The StormForger Command Line Client, called 'forge'"
+brews:
+  - github:
+      owner: stormforger
+      name: homebrew-forge
+    install: bin.install "forge"
+    folder: Formula
+    homepage: "https://stormforger.com"
+    description: "The StormForger Command Line Client, called 'forge'"
 dockers:
 - image_templates:
   - 'stormforger/cli:{{ .Tag }}'


### PR DESCRIPTION
Fixes #77 

See https://goreleaser.com/deprecations/#brew for the deprecation notice.

