### PR TITLE
Allow any region for validation runs

### DIFF
--- a/cmd/testcase_launch.go
+++ b/cmd/testcase_launch.go
@@ -161,7 +161,6 @@ func testRunLaunch(cmd *cobra.Command, args []string) {
 	if testRunLaunchOpts.Validate {
 		launchOptions.SessionValidationMode = true
 		launchOptions.ClusterSizing = "preflight"
-		launchOptions.ClusterRegion = "eu-west-1"
 	}
 
 	status, response, err := client.TestRunCreate(testCaseUID, launchOptions)


### PR DESCRIPTION
There is no need to pin the region for validation testruns anymore.