### PR TITLE
api: Close request body / use time.Since

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -214,6 +214,7 @@ func (c *Client) fetch(path string) (bool, []byte, error) {
 	if err != nil {
 		return false, nil, err
 	}
+	defer response.Body.Close()
 
 	body, err := ioutil.ReadAll(response.Body)
 	if err != nil {

--- a/api/file_fixture.go
+++ b/api/file_fixture.go
@@ -28,6 +28,7 @@ func (c *Client) MoveFileFixture(organization string, fileFixtureUID string, new
 	if err != nil {
 		return false, "", err
 	}
+	defer response.Body.Close()
 
 	body, err := ioutil.ReadAll(response.Body)
 	if err != nil {
@@ -80,6 +81,7 @@ func (c *Client) PushFileFixture(fileName string, data io.Reader, organization s
 	if err != nil {
 		return false, nil, err
 	}
+	defer response.Body.Close()
 
 	body, err := ioutil.ReadAll(response.Body)
 	if err != nil {
@@ -106,6 +108,7 @@ func (c *Client) DeleteFileFixture(fileFixtureUID string, organization string) (
 	if err != nil {
 		return false, "", err
 	}
+	defer response.Body.Close()
 
 	body, err := ioutil.ReadAll(response.Body)
 	if err != nil {

--- a/api/testcase.go
+++ b/api/testcase.go
@@ -38,6 +38,7 @@ func (c *Client) TestCaseValidate(organization string, fileName string, data io.
 	if err != nil {
 		return false, "", err
 	}
+	defer response.Body.Close()
 
 	body, err := ioutil.ReadAll(response.Body)
 	if err != nil {
@@ -72,6 +73,7 @@ func (c *Client) TestCaseCreate(organization string, testCaseName string, fileNa
 	if err != nil {
 		return false, "", err
 	}
+	defer response.Body.Close()
 
 	body, err := ioutil.ReadAll(response.Body)
 	if err != nil {
@@ -104,6 +106,7 @@ func (c *Client) TestCaseUpdate(testCaseUID string, fileName string, data io.Rea
 	if err != nil {
 		return false, "", err
 	}
+	defer response.Body.Close()
 
 	body, err := ioutil.ReadAll(response.Body)
 	if err != nil {

--- a/api/testrun.go
+++ b/api/testrun.go
@@ -75,6 +75,7 @@ func (c *Client) TestRunWatch(uid string) (testrun.TestRun, string, error) {
 	if err != nil {
 		return testrun.TestRun{}, "", err
 	}
+	defer response.Body.Close()
 
 	body, err := ioutil.ReadAll(response.Body)
 	if err != nil {
@@ -131,6 +132,7 @@ func (c *Client) TestRunLogs(path string, preview bool) (io.ReadCloser, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer response.Body.Close()
 
 	if response.StatusCode != 200 {
 		return nil, errors.New("could not download log")
@@ -170,6 +172,7 @@ func (c *Client) TestRunDump(pathID string) (io.ReadCloser, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer response.Body.Close()
 
 	if response.StatusCode != 200 {
 		return nil, errors.New("could not load full dump")
@@ -258,6 +261,7 @@ func (c *Client) TestRunCreate(testCaseUID string, options TestRunLaunchOptions)
 	if err != nil {
 		return false, "", err
 	}
+	defer response.Body.Close()
 
 	body, err := ioutil.ReadAll(response.Body)
 	if err != nil {
@@ -281,6 +285,7 @@ func (c *Client) TestRunAbort(testRunUID string) (bool, string, error) {
 	if err != nil {
 		return false, "", err
 	}
+	defer response.Body.Close()
 
 	body, err := ioutil.ReadAll(response.Body)
 	if err != nil {
@@ -308,6 +313,7 @@ func (c *Client) TestRunNfrCheck(uid string, fileName string, data io.Reader) (b
 	if err != nil {
 		log.Fatal(err)
 	}
+	defer response.Body.Close()
 
 	body, err := ioutil.ReadAll(response.Body)
 	if err != nil {

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -191,7 +191,7 @@ func watchTestRun(testRunUID string, maxWatchTime float64, outputFormat string) 
 	testEnded := false
 
 	for true {
-		runningSince := time.Now().Sub(started).Seconds()
+		runningSince := time.Since(started).Seconds()
 
 		testRun, response, err := client.TestRunWatch(testRunUID)
 		if err != nil {


### PR DESCRIPTION
Small mixed bag:

* Always close response bodies after handling the response
* `time.Since()` is preferred over time.Now().Sub(start)

The former is especially important for long running scenarios i.e. while waiting for a test-run to finish, otherwise memory and network sockets will leak.