### PR TITLE
Add github action to verify + go build on push

### DIFF
--- a/.github/workflows/gobuild.yml
+++ b/.github/workflows/gobuild.yml
@@ -1,0 +1,24 @@
+name: Go
+on: [push]
+jobs:
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Set up Go 1.12
+      uses: actions/setup-go@v1
+      with:
+        go-version: 1.12
+      id: go
+
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v1
+
+    - name: Get dependencies
+      run: |
+        go get -v -mod=readonly -t -d ./...
+
+    - name: Build
+      run: go build -v -mod=readonly .


### PR DESCRIPTION
Travis still seems to be broken and does not provide any feedback for PRs. To prevent the most stupid mistakes of non-compiling code, lets add at least the `go build` stuff for now.