### PR TITLE
feat: treat finished as a successful test-run outcome and do not fail the cli

### DIFF
--- a/cmd/testrun_watch.go
+++ b/cmd/testrun_watch.go
@@ -35,14 +35,15 @@ and 2 if the given timeout was exceeded.`,
 )
 
 var successStates = []string{
-	"launching",
-	"deploying",
-	"starting",
-	"running",
-	"fetching_logs",
-	"log_fetched",
 	"analysing",
+	"deploying",
 	"done",
+	"fetching_logs",
+	"finished",
+	"launching",
+	"log_fetched",
+	"running",
+	"starting",
 }
 
 func init() {


### PR DESCRIPTION
Our nightly integration test-runs recently failed due to the state `finished.
With our new engine the `finished` state is now more visible to the endusers / api / cli, thus showing the fact we forgot to treat it correctly more often.

This PR adds it to our successful list.