### PR TITLE
feat: Allow NFR and traffic dump together

### DIFF
--- a/cmd/testcase_launch.go
+++ b/cmd/testcase_launch.go
@@ -68,10 +68,6 @@ Available cluster regions are available at https://docs.stormforger.com/referenc
 				log.Fatal("Too many arguments")
 			}
 
-			if testRunLaunchOpts.DumpTraffic && testRunLaunchOpts.CheckNFR != "" {
-				log.Fatal("--dump-traffic and --nfr-check-file are mutual exclusive")
-			}
-
 			if testRunLaunchOpts.ClusterRegion != "" && !stringInSlice(testRunLaunchOpts.ClusterRegion, validRegions) {
 				log.Fatalf("%s is not a valid region", testRunLaunchOpts.ClusterRegion)
 			}

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"bufio"
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"io"
 	"log"
@@ -362,7 +363,27 @@ func runNfrCheck(client api.Client, testRunUID string, fileName string, nfrData 
 	}
 
 	if !status {
-		log.Fatalf("Could not perform test run NFR checks...\n%s", result)
+		var response struct {
+			Status  string
+			Message string
+			Error   string
+		}
+
+		log.Println("Could not perform test-run NFR checks...")
+		if err := json.Unmarshal(result, &response); err != nil {
+			log.Println(string(result))
+		} else {
+			if response.Status != "" {
+				log.Printf(" Status:\t%s\n", response.Status)
+			}
+			if response.Message != "" {
+				log.Printf(" Message:\t%s\n", response.Message)
+			}
+			if response.Error != "" {
+				log.Printf(" Error:\t%s\n", response.Error)
+			}
+		}
+		os.Exit(1)
 	}
 
 	items, err := testrun.UnmarshalNfrResults(bytes.NewReader(result))


### PR DESCRIPTION
With our legacy engine we had to disallow using nfr checks and traffic-dump together. This now works with our new loadtest engine. See https://docs.stormforger.com/reference/engine/ for more information.

Additionally this PR formats any NFR api error better instead of dumping just the raw (JSON) response.