### PR TITLE
feat: Add --update flag to test-case create to update test-case if it already exists

### DIFF
--- a/cmd/datasource_delete.go
+++ b/cmd/datasource_delete.go
@@ -21,7 +21,7 @@ var (
 				log.Fatal("Missing organisation")
 			}
 
-			datasourceOpts.Organisation = lookupOrganisationUID(*NewClient(), args[0])
+			datasourceOpts.Organisation = lookupOrganisationUID(NewClient(), args[0])
 			if datasourceOpts.Organisation == "" {
 				log.Fatal("Missing organisation")
 			}

--- a/cmd/datasource_download.go
+++ b/cmd/datasource_download.go
@@ -24,7 +24,7 @@ var (
 				log.Fatal("Missing organisation")
 			}
 
-			datasourceOpts.Organisation = lookupOrganisationUID(*NewClient(), args[0])
+			datasourceOpts.Organisation = lookupOrganisationUID(NewClient(), args[0])
 			if datasourceOpts.Organisation == "" {
 				log.Fatal("Missing organisation")
 			}

--- a/cmd/datasource_list.go
+++ b/cmd/datasource_list.go
@@ -25,7 +25,7 @@ var (
 				log.Fatal("Missing organisation")
 			}
 
-			datasourceOpts.Organisation = lookupOrganisationUID(*NewClient(), args[0])
+			datasourceOpts.Organisation = lookupOrganisationUID(NewClient(), args[0])
 			if datasourceOpts.Organisation == "" {
 				log.Fatal("Missing organisation")
 			}

--- a/cmd/datasource_move.go
+++ b/cmd/datasource_move.go
@@ -19,7 +19,7 @@ var (
 				log.Fatal("Expecting exactly three arguments: organisation, name of source and destination")
 			}
 
-			datasourceOpts.Organisation = lookupOrganisationUID(*NewClient(), args[0])
+			datasourceOpts.Organisation = lookupOrganisationUID(NewClient(), args[0])
 			if datasourceOpts.Organisation == "" {
 				log.Fatal("Missing organisation")
 			}

--- a/cmd/datasource_push.go
+++ b/cmd/datasource_push.go
@@ -41,7 +41,7 @@ var (
 				log.Fatal("Delimiter can only be one character!")
 			}
 
-			datasourceOpts.Organisation = lookupOrganisationUID(*NewClient(), args[0])
+			datasourceOpts.Organisation = lookupOrganisationUID(NewClient(), args[0])
 			if datasourceOpts.Organisation == "" {
 				log.Fatal("Missing organisation")
 			}

--- a/cmd/datasource_show.go
+++ b/cmd/datasource_show.go
@@ -16,7 +16,7 @@ var (
 		Short:   "Show details of fixture",
 		Args:    cobra.ExactArgs(2),
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
-			datasourceOpts.Organisation = lookupOrganisationUID(*NewClient(), args[0])
+			datasourceOpts.Organisation = lookupOrganisationUID(NewClient(), args[0])
 			if datasourceOpts.Organisation == "" {
 				log.Fatal("Missing organisation")
 			}

--- a/cmd/testcase_get.go
+++ b/cmd/testcase_get.go
@@ -43,7 +43,7 @@ func init() {
 func runTestCaseGet(cmd *cobra.Command, args []string) {
 	client := NewClient()
 
-	testCaseUID := lookupTestCase(*client, args[0])
+	testCaseUID := mustLookupTestCase(client, args[0])
 
 	success, response, err := client.DownloadTestCaseDefinition(testCaseUID)
 	if err != nil {

--- a/cmd/testcase_launch.go
+++ b/cmd/testcase_launch.go
@@ -155,7 +155,7 @@ func init() {
 func testRunLaunch(cmd *cobra.Command, args []string) {
 	client := NewClient()
 
-	testCaseUID := lookupTestCase(*client, args[0])
+	testCaseUID := mustLookupTestCase(client, args[0])
 
 	launchOptions := api.TestRunLaunchOptions{
 		Title:                 testRunLaunchOpts.Title,

--- a/cmd/testcase_list.go
+++ b/cmd/testcase_list.go
@@ -26,7 +26,7 @@ var (
 				log.Fatal("Missing organisation")
 			}
 
-			testCaseListOpts.Organisation = lookupOrganisationUID(*NewClient(), args[0])
+			testCaseListOpts.Organisation = lookupOrganisationUID(NewClient(), args[0])
 			if testCaseListOpts.Organisation == "" {
 				log.Fatal("Missing organisation")
 			}

--- a/cmd/testcase_update.go
+++ b/cmd/testcase_update.go
@@ -51,7 +51,7 @@ func init() {
 func runTestCaseUpdate(cmd *cobra.Command, args []string) {
 	client := NewClient()
 
-	testCaseUID := lookupTestCase(*client, args[0])
+	testCaseUID := mustLookupTestCase(client, args[0])
 
 	fileName, testCaseFile, err := readTestCaseFromStdinOrReadFromArgument(args[1], "test_case.js")
 	if err != nil {
@@ -66,12 +66,7 @@ func runTestCaseUpdate(cmd *cobra.Command, args []string) {
 	if rootOpts.OutputFormat == "json" {
 		// if the user wants json, we don't bother to parse it and just dump it.
 		printValidationResultJSON(message)
-
-		if success {
-			os.Exit(0)
-		} else {
-			os.Exit(1)
-		}
+		cmdExit(success)
 	}
 
 	// NOTE: The testcase api endpoint may return an API error with either a 200 or 400.
@@ -85,7 +80,10 @@ func runTestCaseUpdate(cmd *cobra.Command, args []string) {
 	}
 
 	printValidationResultHuman(os.Stderr, fileName, success, errorMeta)
+	cmdExit(success)
+}
 
+func cmdExit(success bool) {
 	if success {
 		os.Exit(0)
 	} else {

--- a/cmd/testcase_validate.go
+++ b/cmd/testcase_validate.go
@@ -54,7 +54,7 @@ Examples
 				}
 			}
 
-			testCaseValidateOpts.Organisation = lookupOrganisationUID(*NewClient(), args[0])
+			testCaseValidateOpts.Organisation = lookupOrganisationUID(NewClient(), args[0])
 			if testCaseValidateOpts.Organisation == "" {
 				log.Fatal("Missing organisation")
 			}

--- a/cmd/testrun_list.go
+++ b/cmd/testrun_list.go
@@ -50,7 +50,7 @@ func init() {
 func testRunList(cmd *cobra.Command, args []string) {
 	client := NewClient()
 
-	testCaseUID := lookupTestCase(*client, args[0])
+	testCaseUID := mustLookupTestCase(client, args[0])
 
 	filter := ""
 	if testRunListOpts.Archived {

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -59,7 +59,7 @@ func findFixtureByName(client api.Client, orga string, name string) *filefixture
 }
 
 // findOrganisationByName fetches a FileFixture from a given Organisation.
-func findOrganisationByName(client api.Client, name string) *organisation.Organisation {
+func findOrganisationByName(client *api.Client, name string) *organisation.Organisation {
 	status, response, err := client.ListOrganisations()
 	if err != nil {
 		log.Fatal(err)
@@ -247,7 +247,7 @@ func watchTestRun(testRunUID string, maxWatchTime float64, outputFormat string) 
 	}
 }
 
-func lookupOrganisationUID(client api.Client, input string) string {
+func lookupOrganisationUID(client *api.Client, input string) string {
 	organisation := findOrganisationByName(client, input)
 	if organisation.ID == "" {
 		log.Fatalf("Organisation %s not found", input)
@@ -256,7 +256,16 @@ func lookupOrganisationUID(client api.Client, input string) string {
 	return organisation.ID
 }
 
-func lookupTestCase(client api.Client, input string) string {
+// mustLookupTestCase returns the ID of the test-case for the given input or calls log.Fatal().
+func mustLookupTestCase(client *api.Client, input string) string {
+	s := lookupTestCase(client, input)
+	if s == "" {
+		log.Fatalf("Test case for query '%s' not found", input)
+	}
+	return s
+}
+
+func lookupTestCase(client *api.Client, input string) string {
 	segments := strings.Split(input, "/")
 	nameOrUID := input
 
@@ -277,10 +286,6 @@ func lookupTestCase(client api.Client, input string) string {
 		}
 
 		testCase := testCases.FindByNameOrUID(nameOrUID)
-		if testCase.ID == "" {
-			log.Fatalf("Test case %s not found", nameOrUID)
-		}
-
 		return testCase.ID
 	}
 

--- a/testdata/cases/valid.js
+++ b/testdata/cases/valid.js
@@ -5,6 +5,9 @@ definition.setArrivalPhases([
   { duration: 15 * 60, rate: 60, max_users: 5000 },
 ]);
 
+definition.setTestOptions({
+  cluster: { sizing: "tiny", }
+})
 definition.session("base", function(session) {
   session.get("/users/configuration", {
     gzip: true,


### PR DESCRIPTION
## Why?

When integrating the `forge` cli into CI/CD pipelines it is annoying for having to create the test-case manually beforehand before running your CI/CD pipeline or even having to do a `forge tc create || forge tc update` fallback logic. 

## What?

* This PR adds the `--update` param to `forge test-case create` to allow for updating the test-case if it already exists.
* We aligned the output and exit-code behavior of `test-case create` with `test-case update`

Also:
* We also made the `lookupTestCase() ` function non-fatal and instead added a `mustLookupTestCase()` with the old behavior
* The removal of `*` in various calls to `NewClient()` was mainly out of "it-felt-dirty"

## Caveats

* We opted for adding this to `test-case create` as we already have all necessary parameters here. (we tried adding it to `test-case update` first)
* No tests, its the client :sadparrot: