### PR TITLE
feat: return a nicer error when we receive a 404 for the calllog/userlog

### DIFF
--- a/api/testrun.go
+++ b/api/testrun.go
@@ -106,7 +106,7 @@ func (c *Client) TestRunCallLog(pathID string, preview bool) (io.ReadCloser, err
 		path += "?preview=true"
 	}
 
-	return c.TestRunLogs(path, preview)
+	return c.TestRunLogs(path)
 }
 
 // TestRunUserLog will download the user logs
@@ -115,12 +115,12 @@ func (c *Client) TestRunUserLog(pathID string) (io.ReadCloser, error) {
 
 	path := "/test_runs/" + testRun.UID + "/user_log"
 
-	return c.TestRunLogs(path, false)
+	return c.TestRunLogs(path)
 }
 
 // TestRunLogs will download logs from the given path. It will also
 // handle compression accordingly.
-func (c *Client) TestRunLogs(path string, preview bool) (io.ReadCloser, error) {
+func (c *Client) TestRunLogs(path string) (io.ReadCloser, error) {
 	req, err := http.NewRequest("GET", c.APIEndpoint+path, nil)
 	if err != nil {
 		return nil, err
@@ -135,6 +135,9 @@ func (c *Client) TestRunLogs(path string, preview bool) (io.ReadCloser, error) {
 
 	if response.StatusCode != 200 {
 		response.Body.Close()
+		if response.StatusCode == 404 {
+			return nil, errors.New("test-run or logs not found")
+		}
 		return nil, errors.New("could not download log")
 	}
 

--- a/api/testrun_test.go
+++ b/api/testrun_test.go
@@ -1,6 +1,8 @@
 package api
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -19,4 +21,18 @@ func TestExtractTestRunResources(t *testing.T) {
 		TestRunResources{Organisation: "zeisss", TestCase: "simple", SequenceID: "10"},
 		ExtractTestRunResources("zeisss/simple/10"),
 	)
+}
+
+// Test that an api response of 404 returns an error with "test-case or logs not found"
+func TestTestRunCallLog_404NotFound(t *testing.T) {
+	srv := httptest.NewServer(http.NotFoundHandler())
+	t.Cleanup(func() { srv.Close() })
+
+	const testCaseUID = "01234567abc"
+	c := NewClient(srv.URL, "")
+	r, err := c.TestRunCallLog(testCaseUID, false)
+	assert.Nil(t, r)
+	assert.NotNil(t, err)
+
+	assert.Equal(t, "test-run or logs not found", err.Error())
 }


### PR DESCRIPTION
Currently we return a confusing "could not download logs" when using `forge tr logs <uid>` with a UID that the user has no access to.

This PR returns a more helpful "test-run or logs not found" for `404 Not Found` status codes. This hopefully reduces the confusion a bit.

```
14:24 $ ./cli tr logs KR1c92R6g
2020/06/19 14:28:04 test-case or logs not found
```