### PR TITLE
feat: allow atomic update and launch for tests

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -145,9 +145,10 @@ func createGZIPFormFile(w *multipart.Writer, fieldname, filename, contenttype st
 	return w.CreatePart(h)
 }
 
-func fileUploadRequest(uri, method string, params map[string]string, fileParamName, fileName, mimeType string, data io.Reader) (*http.Request, error) {
+func fileUploadRequest(uri, method string, params url.Values, fileParamName, fileName, mimeType string, data io.Reader) (*http.Request, error) {
 	body := &bytes.Buffer{}
 	writer := multipart.NewWriter(body)
+
 	part, err := createGZIPFormFile(writer, fileParamName, fileName, mimeType)
 	if err != nil {
 		return nil, err
@@ -161,8 +162,10 @@ func fileUploadRequest(uri, method string, params map[string]string, fileParamNa
 		return nil, err
 	}
 
-	for key, val := range params {
-		_ = writer.WriteField(key, val)
+	for key, valueList := range params {
+		for _, value := range valueList {
+			_ = writer.WriteField(key, value)
+		}
 	}
 	err = writer.Close()
 	if err != nil {

--- a/api/file_fixture.go
+++ b/api/file_fixture.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
+	"net/url"
 )
 
 // FileFixtureParams represents params BLA TODO
@@ -55,21 +56,20 @@ func (c *Client) ListFileFixture(organization string) (bool, []byte, error) {
 
 // PushFileFixture uploads (insert or update) a file fixture
 func (c *Client) PushFileFixture(fileName string, data io.Reader, organization string, params *FileFixtureParams) (bool, []byte, error) {
-	extraParams := map[string]string{
-		"file_fixture[name]": params.Name,
-		"file_fixture[type]": params.Type,
-	}
+	extraParams := url.Values{}
+	extraParams.Add("file_fixture[name]", params.Name)
+	extraParams.Add("file_fixture[type]", params.Type)
 
 	if params.FirstRowHeaders {
-		extraParams["file_fixture[file_fixture_version][first_row_headers]"] = "1"
+		extraParams.Add("file_fixture[file_fixture_version][first_row_headers]", "1")
 	}
 
 	if params.Delimiter != "" {
-		extraParams["file_fixture[file_fixture_version][delimiter]"] = params.Delimiter
+		extraParams.Add("file_fixture[file_fixture_version][delimiter]", params.Delimiter)
 	}
 
 	if params.FieldNames != "" {
-		extraParams["file_fixture[file_fixture_version][field_names]"] = params.FieldNames
+		extraParams.Add("file_fixture[file_fixture_version][field_names]", params.FieldNames)
 	}
 
 	req, err := fileUploadRequest(c.APIEndpoint+"/file_fixtures/"+organization, "POST", extraParams, "file_fixture[file_fixture_version][original]", fileName, "application/octet-stream", data)

--- a/api/har.go
+++ b/api/har.go
@@ -6,12 +6,13 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"net/url"
 )
 
 // Har converts the given HAR archive file into
 // a StormForger test case definition
 func (c *Client) Har(fileName string, data io.Reader) (string, error) {
-	extraParams := map[string]string{}
+	extraParams := url.Values{}
 
 	input, err := ioutil.ReadAll(data)
 	if err != nil {

--- a/api/testcase.go
+++ b/api/testcase.go
@@ -3,6 +3,7 @@ package api
 import (
 	"io"
 	"io/ioutil"
+	"net/url"
 )
 
 // ListTestCases returns a list of test cases
@@ -25,9 +26,8 @@ func (c *Client) TestCaseValidate(organization string, fileName string, data io.
 	// TODO how to pass options here?
 	//      defining a struct maybe, but where?
 	//      finally: add options here
-	extraParams := map[string]string{
-		"organisation_uid": organization,
-	}
+	extraParams := url.Values{}
+	extraParams.Add("organisation_uid", organization)
 
 	req, err := fileUploadRequest(c.APIEndpoint+"/test_cases/validate", "POST", extraParams, "test_case[javascript_definition]", fileName, "application/javascript", data)
 	if err != nil {
@@ -60,9 +60,8 @@ func (c *Client) TestCaseCreate(organization string, testCaseName string, fileNa
 	// TODO how to pass options here?
 	//      defining a struct maybe, but where?
 	//      finally: add options here
-	extraParams := map[string]string{
-		"test_case[name]": testCaseName,
-	}
+	extraParams := url.Values{}
+	extraParams.Add("test_case[name]", testCaseName)
 
 	req, err := fileUploadRequest(c.APIEndpoint+"/organisations/"+organization+"/test_cases", "POST", extraParams, "test_case[javascript_definition]", fileName, "application/javascript", data)
 	if err != nil {
@@ -95,7 +94,7 @@ func (c *Client) TestCaseUpdate(testCaseUID string, fileName string, data io.Rea
 	// TODO how to pass options here?
 	//      defining a struct maybe, but where?
 	//      finally: add options here
-	extraParams := map[string]string{}
+	extraParams := url.Values{}
 
 	req, err := fileUploadRequest(c.APIEndpoint+"/test_cases/"+testCaseUID, "PATCH", extraParams, "test_case[javascript_definition]", fileName, "application/javascript", data)
 	if err != nil {

--- a/api/testrun.go
+++ b/api/testrun.go
@@ -17,8 +17,10 @@ import (
 
 // TestRunLaunchOptions represents a single TestRunLaunchOptions
 type TestRunLaunchOptions struct {
-	Title                 string
-	Notes                 string
+	Title                string
+	Notes                string
+	JavascriptDefinition string
+
 	ClusterRegion         string
 	ClusterSizing         string
 	DisableGzip           bool
@@ -206,8 +208,9 @@ func (c *Client) TestRunCreate(testCaseUID string, options TestRunLaunchOptions)
 	}
 
 	type testAttr struct {
-		Title string `json:"title,omitempty"`
-		Notes string `json:"notes,omitempty"`
+		Title                string `json:"title,omitempty"`
+		Notes                string `json:"notes,omitempty"`
+		JavascriptDefinition string `json:"javascript_definition,omitempty"` // optional javascript definition to update the test-case with
 	}
 
 	type payload struct {
@@ -219,6 +222,7 @@ func (c *Client) TestRunCreate(testCaseUID string, options TestRunLaunchOptions)
 		Data payload `json:"data"`
 	}
 
+	// Only upload test_configuration_attributes if one of option is non-zero for this
 	var testConfig *testConfigAttr
 	if options.DisableGzip ||
 		options.SkipWait ||
@@ -239,8 +243,9 @@ func (c *Client) TestRunCreate(testCaseUID string, options TestRunLaunchOptions)
 	jsonPayload, err := json.Marshal(&payloadContainer{
 		Data: payload{
 			Attributes: testAttr{
-				Title: options.Title,
-				Notes: options.Notes,
+				Title:                options.Title,
+				Notes:                options.Notes,
+				JavascriptDefinition: options.JavascriptDefinition,
 			},
 			TestConfig: testConfig,
 		},

--- a/api/testrun.go
+++ b/api/testrun.go
@@ -9,6 +9,7 @@ import (
 	"io/ioutil"
 	"log"
 	"net/http"
+	"net/url"
 	"strings"
 
 	"github.com/google/jsonapi"
@@ -304,7 +305,7 @@ func (c *Client) TestRunAbort(testRunUID string) (bool, string, error) {
 // TestRunNfrCheck will upload requirements definition
 // and checks if the given test run matches them.
 func (c *Client) TestRunNfrCheck(uid string, fileName string, data io.Reader) (bool, []byte, error) {
-	extraParams := map[string]string{}
+	extraParams := url.Values{}
 
 	path := "/test_runs/" + uid + "/check_nfr"
 

--- a/cmd/testcase_launch.go
+++ b/cmd/testcase_launch.go
@@ -227,6 +227,11 @@ func MainTestRunLaunch(client *api.Client, testCaseSpec string, testRunLaunchOpt
 		if err != nil {
 			log.Fatal(err)
 		}
+
+		if launchOptions.JavascriptDefinition.Reader != nil {
+			fmt.Println("Test-Case successfully updated")
+		}
+
 		fmt.Printf(`Launching test %s
 UID: %s
 Web URL: %s

--- a/cmd/testcase_launch.go
+++ b/cmd/testcase_launch.go
@@ -184,12 +184,8 @@ func MainTestRunLaunch(client *api.Client, testCaseSpec string, testRunLaunchOpt
 			log.Fatalf("Failed to open %s: %v", filename, err)
 		}
 
-		data, err := ioutil.ReadAll(reader)
-		if err != nil {
-			log.Fatalf("Failed to read %s: %v", filename, err)
-		}
-
-		launchOptions.JavascriptDefinition = string(data)
+		launchOptions.JavascriptDefinition.Filename = filename
+		launchOptions.JavascriptDefinition.Reader = reader
 	}
 
 	if testRunLaunchOpts.Validate {

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -82,7 +82,7 @@ func readFromStdinOrReadFromArgument(fileArg, defaultFileName string) (fileName 
 		fileName = filepath.Base(fileArg)
 		reader, err = os.OpenFile(fileArg, os.O_RDONLY, 0755)
 		if err != nil {
-			return "", nil, err
+			return fileName, nil, err
 		}
 	}
 


### PR DESCRIPTION
NOTE: This feature of the API is still in development. This does not yet work with the public API.

This adds a test-case-file parameter to test-case launch and uploads the file as part of the launch api call. The API is intended to update the test-case with this new definition and launch a test-run immediately.

```
$ forge tc launch sf_dev/sandbox --title="foo" --notes="bar" --dump-traffic --session-validation-mode=false --sizing=tiny --test-case-file=./test.js
Launching test sf_dev/sandbox/77
UID: u6FsTQfv
Web URL: http://127.0.0.1:3000/tr/u6FsTQfv
Configuration: tiny cluster in vagrant
  [✓] Traffic Dump
```