### PR TITLE
fix: parse and format errors from the API for tc launch nicely

### DIFF
--- a/cmd/testcase_launch.go
+++ b/cmd/testcase_launch.go
@@ -199,10 +199,13 @@ func MainTestRunLaunch(client *api.Client, testCaseSpec string, testRunLaunchOpt
 	}
 
 	if !status {
-		fmt.Fprintln(os.Stderr, "Could not launch test run!")
-		fmt.Println(response)
+		errorMeta, err := api.UnmarshalErrorMeta(strings.NewReader(response))
+		if err != nil {
+			log.Fatal(err)
+		}
 
-		os.Exit(1)
+		printValidationResultHuman(os.Stderr, launchOptions.JavascriptDefinition.Filename, status, errorMeta)
+		cmdExit(status)
 	}
 
 	testRun, err := testrun.UnmarshalSingle(strings.NewReader(response))


### PR DESCRIPTION
When adding the "Atomic Update & Launch" feature we forgot that the API can now return validation errors. We actually haven't parsed them nicely at all so far anyway.

This PR treats the response as a JSONAPI error (see https://jsonapi.org/format/#errors) and parses it via the same logic we use in `tc create` and `tc update`.

Note that we are updating the API to return JSONAPI Errors here for other validation errors as well.