### PR TITLE
feat(cmd/ping):  print service account UID and name instead of email

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -1,6 +1,16 @@
 package api
 
+const (
+	UserTypeServiceAccount = "service-account"
+	UserTypeUser           = "user"
+)
+
 // User describes a API user
 type User struct {
-	Mail string `json:"user_email"`
+	Mail            string `json:"user_email"`
+	AuthenticatedAs *struct {
+		UID   string `json:"uid"`
+		Label string `json:"label"`
+		Type  string `json:"type"` // "service-account" or "user"
+	} `json:"authenticated_as"`
 }

--- a/cmd/ping.go
+++ b/cmd/ping.go
@@ -71,7 +71,7 @@ func runPingCmd(cmd *cobra.Command, args []string) {
 		Unauthenticated: pingOpts.Unauthenticated,
 		Subject:         user,
 	}
-	printPingCommandResult(os.Stderr, result)
+	printPingCommandResult(os.Stdout, result)
 }
 
 func PrintHumanPingResult(w io.Writer, result PingCommandResult) {

--- a/cmd/ping.go
+++ b/cmd/ping.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -30,90 +31,82 @@ func init() {
 	pingCmd.Flags().BoolVarP(&pingOpts.Unauthenticated, "unauthenticated", "", false, "Perform unauthenticated ping")
 }
 
+type PingCommandResult struct {
+	Success  bool            `json:"success"`            // set to true if the ping was successful
+	Error    error           `json:"error,omitempty"`    // Available if the ping call failed on a fundamental way (network error, unparsable response etc)
+	Response json.RawMessage `json:"response,omitempty"` // Available if we talked to the StormForger API
+
+	Unauthenticated bool      `json:"unauthenticated"`   // True if the ping command was unauthenticated
+	Subject         *api.User `json:"subject,omitempty"` // Available if the ping suceeded and was an authenticated ping
+}
+
 func runPingCmd(cmd *cobra.Command, args []string) {
 	client := NewClient()
 
-	var printPingError func(bool, []byte, error) = printHumanPingError
-	var printPingSuccess func(bool, *api.User) = printHumanPingSuccess
+	var printPingCommandResult func(io.Writer, PingCommandResult) = PrintHumanPingResult
 	if rootOpts.OutputFormat == "json" {
-		printPingError = printJSONPingError
-		printPingSuccess = printJSONPingSuccess
+		printPingCommandResult = printJSONPingResult
 	}
 
 	var status bool
 	var response []byte
 	var err error
+	var user *api.User
 
 	if pingOpts.Unauthenticated {
 		status, response, err = client.PingUnauthenticated()
-		if !status {
-			printPingError(false, response, err)
-			os.Exit(1)
-		}
-		printPingSuccess(false, nil)
 	} else {
 		status, response, err = client.Ping()
-		if !status {
-			printPingError(true, response, err)
-			os.Exit(1)
+		if status {
+			var u api.User
+			err = json.NewDecoder(bytes.NewReader(response)).Decode(&u)
+			user = &u
 		}
-		var data api.User
-		if err := json.NewDecoder(bytes.NewReader(response)).Decode(&data); err != nil {
-			printPingError(true, response, err)
-			os.Exit(1)
-		}
-		printPingSuccess(true, &data)
+	}
+
+	result := PingCommandResult{
+		Success:         status,
+		Error:           err,
+		Response:        response,
+		Unauthenticated: pingOpts.Unauthenticated,
+		Subject:         user,
+	}
+	printPingCommandResult(os.Stderr, result)
+}
+
+func PrintHumanPingResult(w io.Writer, result PingCommandResult) {
+	if result.Success {
+		printHumanPingSuccess(w, !result.Unauthenticated, result.Subject)
+	} else {
+		printHumanPingError(w, !result.Unauthenticated, result.Response, result.Error)
 	}
 }
 
-func printHumanPingSuccess(authenticated bool, data *api.User) {
+func printHumanPingSuccess(w io.Writer, authenticated bool, data *api.User) {
 	if authenticated {
 		if data.AuthenticatedAs.Type == api.UserTypeServiceAccount {
-			fmt.Printf("PONG! Authenticated as %s (%s)\n", data.AuthenticatedAs.Label, data.AuthenticatedAs.UID)
+			fmt.Fprintf(w, "PONG! Authenticated as %s (%s)\n", data.AuthenticatedAs.Label, data.AuthenticatedAs.UID)
 		} else {
-			fmt.Printf("PONG! Authenticated as %s\n", data.Mail)
+			fmt.Fprintf(w, "PONG! Authenticated as %s\n", data.Mail)
 		}
 	} else {
-		fmt.Println("PONG!")
+		fmt.Fprintln(w, "PONG!")
 	}
 }
 
-func printHumanPingError(authenticated bool, response []byte, err error) {
+func printHumanPingError(w io.Writer, authenticated bool, response []byte, err error) {
 	if authenticated {
-		fmt.Print("Could not perform authenticated ping!")
+		fmt.Fprint(w, "Could not perform authenticated ping!")
 	} else {
-		fmt.Print("Could not perform ping!")
+		fmt.Fprint(w, "Could not perform ping!")
 	}
-	fmt.Println(" Please verify that you can login with these credentials at https://app.stormforger.com!")
+	fmt.Fprintln(w, " Please verify that you can login with these credentials at https://app.stormforger.com!")
 
 	if err != nil {
-		fmt.Println("ERROR:", err)
+		fmt.Fprintln(w, "ERROR:", err)
 	}
 }
 
-type pingLogMessage struct {
-	Error       bool            `json:"error"`
-	Message     string          `json:"message,omitempty"`
-	APIResponse json.RawMessage `json:"api_response,omitempty"`
-	User        *api.User       `json:"user,omitempty"`
-}
-
-func printJSONPingSuccess(authenticated bool, user *api.User) {
-	logMessage := pingLogMessage{
-		Error:   false,
-		Message: "PONG!",
-		User:    user,
-	}
-	json.NewEncoder(os.Stderr).Encode(logMessage)
-}
-
-func printJSONPingError(_authenticated bool, jsonResponse []byte, err error) {
-	logMessage := pingLogMessage{
-		Error:       true,
-		APIResponse: jsonResponse,
-	}
-	if err != nil {
-		logMessage.Message = err.Error()
-	}
-	json.NewEncoder(os.Stderr).Encode(logMessage)
+func printJSONPingResult(w io.Writer, result PingCommandResult) {
+	json.NewEncoder(w).Encode(result)
 }

--- a/cmd/ping.go
+++ b/cmd/ping.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"log"
+	"os"
 
 	"github.com/spf13/cobra"
 	"github.com/stormforger/cli/api"
@@ -24,8 +24,21 @@ var (
 	}
 )
 
+func init() {
+	RootCmd.AddCommand(pingCmd)
+
+	pingCmd.Flags().BoolVarP(&pingOpts.Unauthenticated, "unauthenticated", "", false, "Perform unauthenticated ping")
+}
+
 func runPingCmd(cmd *cobra.Command, args []string) {
 	client := NewClient()
+
+	var printPingError func(bool, []byte, error) = printHumanPingError
+	var printPingSuccess func(bool, *api.User) = printHumanPingSuccess
+	if rootOpts.OutputFormat == "json" {
+		printPingError = printJSONPingError
+		printPingSuccess = printJSONPingSuccess
+	}
 
 	var status bool
 	var response []byte
@@ -33,39 +46,74 @@ func runPingCmd(cmd *cobra.Command, args []string) {
 
 	if pingOpts.Unauthenticated {
 		status, response, err = client.PingUnauthenticated()
-
 		if !status {
-			fmt.Println("Could not perform ping! Please verify that you can connect to https://api.stormforger.com")
-			if err != nil {
-				log.Println(err)
-			}
-			log.Fatal(string(response))
-		} else {
-			fmt.Println("PONG!")
+			printPingError(false, response, err)
+			os.Exit(1)
 		}
-
+		printPingSuccess(false, nil)
 	} else {
 		status, response, err = client.Ping()
-
 		if !status {
-			fmt.Println("Could not perform authenticated ping! Please verify that you can login with these credentials at https://app.stormforger.com!")
-			if err != nil {
-				log.Println(err)
-			}
-			log.Fatal(string(response))
-		} else {
-			var data api.User
-			if err := json.NewDecoder(bytes.NewReader(response)).Decode(&data); err != nil {
-				log.Fatal(err)
-			}
-
-			fmt.Printf("PONG! Authenticated as %s\n", data.Mail)
+			printPingError(true, response, err)
+			os.Exit(1)
 		}
+		var data api.User
+		if err := json.NewDecoder(bytes.NewReader(response)).Decode(&data); err != nil {
+			printPingError(true, response, err)
+			os.Exit(1)
+		}
+		printPingSuccess(true, &data)
 	}
 }
 
-func init() {
-	RootCmd.AddCommand(pingCmd)
+func printHumanPingSuccess(authenticated bool, data *api.User) {
+	if authenticated {
+		if data.AuthenticatedAs.Type == api.UserTypeServiceAccount {
+			fmt.Printf("PONG! Authenticated as %s (%s)\n", data.AuthenticatedAs.Label, data.AuthenticatedAs.UID)
+		} else {
+			fmt.Printf("PONG! Authenticated as %s\n", data.Mail)
+		}
+	} else {
+		fmt.Println("PONG!")
+	}
+}
 
-	pingCmd.Flags().BoolVarP(&pingOpts.Unauthenticated, "unauthenticated", "", false, "Perform unauthenticated ping")
+func printHumanPingError(authenticated bool, response []byte, err error) {
+	if authenticated {
+		fmt.Print("Could not perform authenticated ping!")
+	} else {
+		fmt.Print("Could not perform ping!")
+	}
+	fmt.Println(" Please verify that you can login with these credentials at https://app.stormforger.com!")
+
+	if err != nil {
+		fmt.Println("ERROR:", err)
+	}
+}
+
+type pingLogMessage struct {
+	Error       bool            `json:"error"`
+	Message     string          `json:"message,omitempty"`
+	APIResponse json.RawMessage `json:"api_response,omitempty"`
+	User        *api.User       `json:"user,omitempty"`
+}
+
+func printJSONPingSuccess(authenticated bool, user *api.User) {
+	logMessage := pingLogMessage{
+		Error:   false,
+		Message: "PONG!",
+		User:    user,
+	}
+	json.NewEncoder(os.Stderr).Encode(logMessage)
+}
+
+func printJSONPingError(_authenticated bool, jsonResponse []byte, err error) {
+	logMessage := pingLogMessage{
+		Error:       true,
+		APIResponse: jsonResponse,
+	}
+	if err != nil {
+		logMessage.Message = err.Error()
+	}
+	json.NewEncoder(os.Stderr).Encode(logMessage)
 }

--- a/cmd/ping_test.go
+++ b/cmd/ping_test.go
@@ -1,0 +1,76 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stormforger/cli/api"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPingCommandOutput_Unauthenticated(t *testing.T) {
+	var w strings.Builder
+
+	// For unauthenticated pings, we have no subject or anything else.
+	result := PingCommandResult{
+		Success:         true,
+		Unauthenticated: true,
+	}
+	PrintHumanPingResult(&w, result)
+
+	assert.Equal(t, "PONG!\n", w.String())
+}
+
+func TestPingCommandOutput_ServiceAccount(t *testing.T) {
+	var w strings.Builder
+
+	// For unauthenticated pings, we have no subject or anything else.
+	user := api.User{
+		Mail: "test-UID@noreplay.stormforger.com",
+	}
+	user.AuthenticatedAs = &struct {
+		UID   string "json:\"uid\""
+		Label string "json:\"label\""
+		Type  string "json:\"type\""
+	}{
+		UID:   "myUID",
+		Label: "testname",
+		Type:  api.UserTypeServiceAccount,
+	}
+
+	result := PingCommandResult{
+		Success:         true,
+		Unauthenticated: false,
+		Subject:         &user,
+	}
+	PrintHumanPingResult(&w, result)
+
+	assert.Equal(t, "PONG! Authenticated as testname (myUID)\n", w.String())
+}
+
+func TestPingCommandOutput_User(t *testing.T) {
+	var w strings.Builder
+
+	// For unauthenticated pings, we have no subject or anything else.
+	user := api.User{
+		Mail: "mr.smith@loadtest.party",
+	}
+	user.AuthenticatedAs = &struct {
+		UID   string "json:\"uid\""
+		Label string "json:\"label\""
+		Type  string "json:\"type\""
+	}{
+		UID:   "myUID",
+		Label: "smith",
+		Type:  api.UserTypeUser,
+	}
+
+	result := PingCommandResult{
+		Success:         true,
+		Unauthenticated: false,
+		Subject:         &user,
+	}
+	PrintHumanPingResult(&w, result)
+
+	assert.Equal(t, "PONG! Authenticated as mr.smith@loadtest.party\n", w.String())
+}


### PR DESCRIPTION
#### Why?

We recently added service-accounts which are organisation bound API tokens. These accounts have a unique token that can be used to talk for our API without having to register a shared dedicated user for your CI/CD pipeline or other integrations.

This PR updated the output of `forge ping` to print the service account label and UID instead of the email adress to better indicate that this is not a personal account you are operating on.

### What?

* Added new fields to `api.User` to store new response fields
* Refactored the ping command to construct a result object and hand it off to a printer for writing to stderr
* Added json support by replacing the formatter function with a json encoder, if output is `json`
* Added unit tests for the formatters
