### PR TITLE
refactor: use cobra.ExactArgs() and cobra.MinimumNArgs() for argument length validation

### DIFF
--- a/cmd/datasource_delete.go
+++ b/cmd/datasource_delete.go
@@ -11,21 +11,14 @@ var (
 		Use:     "rm <organisation-ref> <name>",
 		Aliases: []string{"delete", "remove"},
 		Short:   "Delete a fixture",
-		Run:     runDatasourceDelete,
+		Args:    cobra.ExactArgs(2),
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
-			if len(args) > 2 {
-				log.Fatal("Too many arguments")
-			}
-
-			if len(args) < 1 {
-				log.Fatal("Missing organisation")
-			}
-
 			datasourceOpts.Organisation = lookupOrganisationUID(NewClient(), args[0])
 			if datasourceOpts.Organisation == "" {
 				log.Fatal("Missing organisation")
 			}
 		},
+		Run: runDatasourceDelete,
 	}
 )
 

--- a/cmd/datasource_download.go
+++ b/cmd/datasource_download.go
@@ -14,21 +14,14 @@ var (
 		Use:     "get <organisation-ref> <name>",
 		Aliases: []string{"download"},
 		Short:   "Download file fixture",
-		Run:     runDatasourceDownload,
+		Args:    cobra.ExactArgs(2),
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
-			if len(args) > 2 {
-				log.Fatal("Too many arguments")
-			}
-
-			if len(args) < 1 {
-				log.Fatal("Missing organisation")
-			}
-
 			datasourceOpts.Organisation = lookupOrganisationUID(NewClient(), args[0])
 			if datasourceOpts.Organisation == "" {
 				log.Fatal("Missing organisation")
 			}
 		},
+		Run: runDatasourceDownload,
 	}
 
 	downloadOpts struct {

--- a/cmd/datasource_list.go
+++ b/cmd/datasource_list.go
@@ -15,21 +15,14 @@ var (
 		Use:     "list <organisation-ref>",
 		Aliases: []string{"ls"},
 		Short:   "List fixtures",
-		Run:     runDataSourceList,
+		Args:    cobra.ExactArgs(1),
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
-			if len(args) > 1 {
-				log.Fatal("Too many arguments")
-			}
-
-			if len(args) < 1 {
-				log.Fatal("Missing organisation")
-			}
-
 			datasourceOpts.Organisation = lookupOrganisationUID(NewClient(), args[0])
 			if datasourceOpts.Organisation == "" {
 				log.Fatal("Missing organisation")
 			}
 		},
+		Run: runDataSourceList,
 	}
 )
 

--- a/cmd/datasource_move.go
+++ b/cmd/datasource_move.go
@@ -13,17 +13,14 @@ var (
 		Use:     "mv <organisation-ref> <name> <new-name>",
 		Aliases: []string{"move", "rename"},
 		Short:   "Rename a fixture",
-		Run:     runDataSourceMove,
+		Args:    cobra.ExactArgs(3),
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
-			if len(args) != 3 {
-				log.Fatal("Expecting exactly three arguments: organisation, name of source and destination")
-			}
-
 			datasourceOpts.Organisation = lookupOrganisationUID(NewClient(), args[0])
 			if datasourceOpts.Organisation == "" {
 				log.Fatal("Missing organisation")
 			}
 		},
+		Run: runDataSourceMove,
 	}
 )
 

--- a/cmd/datasource_push.go
+++ b/cmd/datasource_push.go
@@ -17,13 +17,10 @@ import (
 
 var (
 	datasourcePushCmd = &cobra.Command{
-		Use:   "push <organisation-ref> <file>",
+		Use:   "push <organisation-ref> <files...>",
 		Short: "Upload a file",
+		Args:  cobra.MinimumNArgs(2),
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
-			if len(args) < 2 {
-				log.Fatal("Expecting one or more arguments: organisation and file(s) to upload")
-			}
-
 			if pushOpts.Raw && (pushOpts.FieldNames != "" || pushOpts.Delimiter != "" || pushOpts.FirstRowHeaders) {
 				log.Fatal("Raw file fixtures do not support --fields, --delimiter and --auto-field-names")
 			}

--- a/cmd/har.go
+++ b/cmd/har.go
@@ -9,18 +9,15 @@ import (
 
 var (
 	harCmd = &cobra.Command{
-		Use:   "har FILE",
+		Use:   "har <file>",
 		Short: "Convert HAR to test case",
-		Long:  `Will convert a given HAR archive into a StormForger test case definition.`,
+		Long:  `Will convert a given HAR archive into a StormForger test case definition. Pass - for the file to read from stdin.`,
+		Args:  cobra.ExactArgs(1),
 		Run:   runHar,
 	}
 )
 
 func runHar(cmd *cobra.Command, args []string) {
-	if len(args) == 0 {
-		log.Fatal("Missing argument: HAR file or - to read from stdin")
-	}
-
 	fileName, harFile, err := readFromStdinOrReadFromArgument(args[0], "stdin")
 	if err != nil {
 		log.Fatal(err)

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -28,7 +28,8 @@ var (
 
 	It is discouraged to provide the password via the --password flag. By
 	default you are asked to provide the password interactively.`,
-		Run: runLogin,
+		Args: cobra.RangeArgs(0, 1),
+		Run:  runLogin,
 	}
 )
 


### PR DESCRIPTION
#### Why?

The datasource subcommands all had bugs where you could pass only one argument and the command would panic. This PR replaces our own argument length validation with the builtin cobra one.
