### PR TITLE
Improve Bash Completion

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -4,13 +4,22 @@ release:
     owner: stormforger
     name: cli
 brews:
-  - github:
+  - tap:
       owner: stormforger
       name: homebrew-forge
-    install: bin.install "forge"
     folder: Formula
     homepage: "https://stormforger.com"
     description: "The StormForger Command Line Client, called 'forge'"
+    install: |
+      bin.install "forge"
+
+      # generate and install bash completion
+      output = Utils.safe_popen_read("#{bin}/forge", "completion", "bash")
+      (bash_completion/"forge").write output
+
+      # generate and install zsh completion
+      output = Utils.safe_popen_read("#{bin}/forge", "completion", "zsh")
+      (zsh_completion/"_forge").write output
 dockers:
 - image_templates:
   - 'stormforger/cli:{{ .Tag }}'

--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -1,67 +1,141 @@
 package cmd
 
 import (
+	"bytes"
+	"fmt"
 	"log"
 	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
+	"github.com/stormforger/cli/api/organisation"
+	"github.com/stormforger/cli/api/testcase"
 )
 
-// CompletionCmd is the command to generate bash/zsh completion
-var CompletionCmd = &cobra.Command{
-	Use:   "completion",
-	Short: "Create completion files for bash and zsh.",
-	Long: `Create shell completion code to tab-complete forge's commands.
+var completionCmd = &cobra.Command{
+	Use:   "completion [bash|zsh|fish|powershell]",
+	Short: "Generate completion script",
+	Long: `To load completions:
 
-The generated completion files will be output in the current folder:
-- forge-completion-bash.sh
-- forge-completion-zsh.sh
+Bash:
 
-Zsh (experimental)
-------------------
-1. Rename forge-completion-zsh.sh to _forge and move it into a directory
-   that is part of your $fpath
-2. Re-initialize your completion files:
-   rm -f ~/.zcompdump; compinit
+$ source <(yourprogram completion bash)
 
-Bash
-----
-To enable bash completion for forge:
-1. Edit your ~/.bash_profile and add a line like this:
-   source /path/to/forge-completion-bash.sh
-2. Start a new terminal session
+# To load completions for each session, execute once:
+Linux:
+  $ yourprogram completion bash > /etc/bash_completion.d/yourprogram
+MacOS:
+  $ yourprogram completion bash > /usr/local/etc/bash_completion.d/yourprogram
+
+Zsh:
+
+# If shell completion is not already enabled in your environment you will need
+# to enable it.  You can execute the following once:
+
+$ echo "autoload -U compinit; compinit" >> ~/.zshrc
+
+# To load completions for each session, execute once:
+$ yourprogram completion zsh > "${fpath[1]}/_yourprogram"
+
+# You will need to start a new shell for this setup to take effect.
+
+Fish:
+
+$ yourprogram completion fish | source
+
+# To load completions for each session, execute once:
+$ yourprogram completion fish > ~/.config/fish/completions/yourprogram.fish
 `,
-	Run: generateCompletionFiles,
+	DisableFlagsInUseLine: true,
+	ValidArgs:             []string{"bash", "zsh", "fish", "powershell"},
+	Args:                  cobra.ExactValidArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		switch args[0] {
+		case "bash":
+			cmd.Root().GenBashCompletion(os.Stdout)
+		case "zsh":
+			cmd.Root().GenZshCompletion(os.Stdout)
+		case "fish":
+			cmd.Root().GenFishCompletion(os.Stdout, true)
+		case "powershell":
+			cmd.Root().GenPowerShellCompletion(os.Stdout)
+		}
+	},
 }
-
-const (
-	completionFileNameBash string = "forge-completion-bash.sh"
-	completionFileNameZsh  string = "forge-completion-zsh.sh"
-)
 
 func init() {
-	RootCmd.AddCommand(CompletionCmd)
+	RootCmd.AddCommand(completionCmd)
 }
 
-func generateCompletionFiles(cmd *cobra.Command, args []string) {
-	log.Printf("Creating completion file for bash in %s\n", completionFileNameBash)
-	err := RootCmd.GenBashCompletionFile(completionFileNameBash)
+func completeOrgaAndCase(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	if strings.Contains(toComplete, "/") {
+		return completionTestCases(toComplete), cobra.ShellCompDirectiveNoFileComp
+	}
+	return completionOrganisations(toComplete, "/"), cobra.ShellCompDirectiveNoFileComp | cobra.ShellCompDirectiveNoSpace
+}
+
+func completeOrga(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	return completionOrganisations(toComplete, ""), cobra.ShellCompDirectiveNoFileComp
+}
+
+func completionOrganisations(toComplete, suffix string) []string {
+	client := NewClient()
+
+	success, result, err := client.ListOrganisations()
 	if err != nil {
 		log.Fatal(err)
 	}
-	err = os.Chmod(completionFileNameBash, 0777)
+	if !success {
+		log.Fatal(string(result))
+	}
+
+	items, err := organisation.Unmarshal(bytes.NewReader(result))
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	log.Printf("Creating completion file for zsh in %s\n", completionFileNameZsh)
-	err = RootCmd.GenZshCompletionFile(completionFileNameZsh)
+	out := []string{}
+	for _, item := range items.Organisations {
+		if toComplete == "" || strings.HasPrefix(item.Name, toComplete) {
+			out = append(out, item.Name+suffix)
+		}
+	}
+
+	return out
+}
+
+func completionTestCases(toComplete string) []string {
+	client := NewClient()
+
+	x := strings.Split(toComplete, "/")
+	orgaName := x[0]
+	tcPrefix := x[1]
+
+	orgaUID := lookupOrganisationUID(client, orgaName)
+
+	status, result, err := client.ListTestCases(orgaUID, "")
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	err = os.Chmod(completionFileNameZsh, 0777)
+	if !status {
+		fmt.Fprintln(os.Stderr, "Could not list test cases for "+orgaUID)
+		fmt.Fprintln(os.Stderr, string(result))
+
+		os.Exit(1)
+	}
+
+	items, err := testcase.Unmarshal(bytes.NewReader(result))
 	if err != nil {
 		log.Fatal(err)
 	}
+
+	out := []string{}
+	for _, item := range items.TestCases {
+		if strings.HasPrefix(item.Name, tcPrefix) {
+			out = append(out, orgaName+"/"+item.Name)
+		}
+	}
+
+	return out
 }

--- a/cmd/datasource_delete.go
+++ b/cmd/datasource_delete.go
@@ -18,7 +18,8 @@ var (
 				log.Fatal("Missing organisation")
 			}
 		},
-		Run: runDatasourceDelete,
+		Run:               runDatasourceDelete,
+		ValidArgsFunction: completeOrga,
 	}
 )
 

--- a/cmd/datasource_download.go
+++ b/cmd/datasource_download.go
@@ -21,7 +21,8 @@ var (
 				log.Fatal("Missing organisation")
 			}
 		},
-		Run: runDatasourceDownload,
+		Run:               runDatasourceDownload,
+		ValidArgsFunction: completeOrga,
 	}
 
 	downloadOpts struct {

--- a/cmd/datasource_list.go
+++ b/cmd/datasource_list.go
@@ -22,7 +22,8 @@ var (
 				log.Fatal("Missing organisation")
 			}
 		},
-		Run: runDataSourceList,
+		Run:               runDataSourceList,
+		ValidArgsFunction: completeOrga,
 	}
 )
 

--- a/cmd/datasource_move.go
+++ b/cmd/datasource_move.go
@@ -20,7 +20,8 @@ var (
 				log.Fatal("Missing organisation")
 			}
 		},
-		Run: runDataSourceMove,
+		Run:               runDataSourceMove,
+		ValidArgsFunction: completeOrga,
 	}
 )
 

--- a/cmd/datasource_push.go
+++ b/cmd/datasource_push.go
@@ -46,6 +46,7 @@ var (
 			client := NewClient()
 			MainDataSourcePush(client, pushOpts, args)
 		},
+		ValidArgsFunction: completeOrga,
 	}
 
 	pushOpts PushOpts

--- a/cmd/datasource_show.go
+++ b/cmd/datasource_show.go
@@ -21,7 +21,8 @@ var (
 				log.Fatal("Missing organisation")
 			}
 		},
-		Run: runDatasourceShow,
+		Run:               runDatasourceShow,
+		ValidArgsFunction: completeOrga,
 	}
 )
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -109,4 +109,8 @@ func init() {
 	RootCmd.PersistentFlags().StringVar(&rootOpts.APIEndpoint, "endpoint", "https://api.stormforger.com", "API Endpoint")
 	RootCmd.PersistentFlags().StringVar(&rootOpts.JWT, "jwt", "", "JWT access token")
 	RootCmd.PersistentFlags().StringVar(&rootOpts.OutputFormat, "output", "human", "Output format: human,plain,json")
+
+	RootCmd.RegisterFlagCompletionFunc("output", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		return stringutil.FilterByPrefix(toComplete, []string{"human", "plain", "json"}), cobra.ShellCompDirectiveDefault
+	})
 }

--- a/cmd/testcase_create.go
+++ b/cmd/testcase_create.go
@@ -59,6 +59,7 @@ cat cases/checkout_process.js | forge test-case create acme-inc/checkout -
 				log.Fatal("Missing test case name")
 			}
 		},
+		ValidArgsFunction: completeOrgaAndCase,
 	}
 
 	testCaseCreateOpts struct {

--- a/cmd/testcase_get.go
+++ b/cmd/testcase_get.go
@@ -33,6 +33,7 @@ to write to.
 				log.Fatal("Too many arguments")
 			}
 		},
+		ValidArgsFunction: completeOrgaAndCase,
 	}
 )
 

--- a/cmd/testcase_launch.go
+++ b/cmd/testcase_launch.go
@@ -80,6 +80,7 @@ Available cluster regions are available at https://docs.stormforger.com/referenc
 			client := NewClient()
 			MainTestRunLaunch(client, args[0], testRunLaunchOpts)
 		},
+		ValidArgsFunction: completeOrgaAndCase,
 	}
 
 	testRunLaunchOpts testRunLaunchCmdOpts

--- a/cmd/testcase_launch.go
+++ b/cmd/testcase_launch.go
@@ -161,6 +161,16 @@ func init() {
 	testRunLaunchCmd.Flags().BoolVar(&testRunLaunchOpts.DumpTraffic, "dump-traffic", false, "Create traffic dump")
 	testRunLaunchCmd.Flags().BoolVar(&testRunLaunchOpts.SessionValidationMode, "session-validation-mode", false, "Enable session validation mode")
 	testRunLaunchCmd.Flags().BoolVar(&testRunLaunchOpts.Validate, "validate", false, "Perform validation run")
+
+	// hints for completion of flags
+	testRunLaunchCmd.MarkFlagFilename("test-case-file", "js")
+	testRunLaunchCmd.MarkFlagFilename("nfr-check-file", "yml", "yaml")
+	testRunLaunchCmd.RegisterFlagCompletionFunc("region", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		return stringutil.FilterByPrefix(toComplete, validRegions), cobra.ShellCompDirectiveDefault
+	})
+	testRunLaunchCmd.RegisterFlagCompletionFunc("sizing", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		return stringutil.FilterByPrefix(toComplete, validSizings), cobra.ShellCompDirectiveDefault
+	})
 }
 
 // MainTestRunLaunch runs a test-case and allows watching and validation that test-run.

--- a/cmd/testcase_list.go
+++ b/cmd/testcase_list.go
@@ -31,6 +31,7 @@ var (
 				log.Fatal("Missing organisation")
 			}
 		},
+		ValidArgsFunction: completeOrga,
 	}
 
 	testCaseListOpts struct {

--- a/cmd/testcase_update.go
+++ b/cmd/testcase_update.go
@@ -41,6 +41,7 @@ Examples
 				log.Fatal("Too many arguments")
 			}
 		},
+		ValidArgsFunction: completeOrgaAndCase,
 	}
 )
 

--- a/cmd/testcase_validate.go
+++ b/cmd/testcase_validate.go
@@ -59,6 +59,7 @@ Examples
 				log.Fatal("Missing organisation")
 			}
 		},
+		ValidArgsFunction: completeOrga,
 	}
 
 	testCaseValidateOpts struct {

--- a/internal/stringutil/stringutil.go
+++ b/internal/stringutil/stringutil.go
@@ -1,6 +1,8 @@
 // Package stringutil provides common string operations.
 package stringutil
 
+import "strings"
+
 // InSlice returns true if a is in the slice list.
 func InSlice(a string, list []string) bool {
 	for _, b := range list {
@@ -9,4 +11,15 @@ func InSlice(a string, list []string) bool {
 		}
 	}
 	return false
+}
+
+// FilterByPrefix returns a prefix-filtered string slice.
+func FilterByPrefix(prefix string, list []string) []string {
+	for _, item := range list {
+		if strings.HasPrefix(item, prefix) {
+			list = append(list, item)
+		}
+	}
+
+	return list
 }


### PR DESCRIPTION
This PR makes a breaking change the `forge completion` command, which generates completion scripts. It now accepts an argument to generate completion scripts for bash, zsh, fish or powershell.

Example:

```terminal
$ forge completion zsh > ./forge-zsh.sh
$ source ./forge-zsh.sh
```

This PR also adds dynamic completion for the following commands:

* root: `--ouput` is completed
* Test Case: Completion for `orga/test-case` references (or just `orga` where applicable)
* Test Case Launch:
  * `--region` and `--sizing` flags are completed
  * `test-case-file` and `nfr-check-file` have hints to filter for `*.js` and `*.yaml`
* Data Source commands do now complete the organisation