### PR TITLE
Update docker image to ubuntu 20.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:19.10
+FROM ubuntu:20.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
Ubuntu 19.10 seems to fail when doing apt-get updates etc, so Ubuntu 20.04 it is.