### PR TITLE
feat: remove broken --organisation flag for datasource subcommand

### DIFF
--- a/cmd/datasource.go
+++ b/cmd/datasource.go
@@ -16,6 +16,4 @@ var (
 
 func init() {
 	RootCmd.AddCommand(datasourceCmd)
-
-	datasourceCmd.PersistentFlags().StringVarP(&datasourceOpts.Organisation, "organisation", "o", "", "Name of the organisation")
 }


### PR DESCRIPTION
It was overwritten for each of the datasource subcommands, so setting it does nothing and only creates confusion.