### PR TITLE
api/client.go: Skip fingerprint verification for non-forge hosts

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -31,30 +31,30 @@ func newDialer(fingerprint []byte, skipCAVerification bool) dialer {
 			return c, err
 		}
 
-    if addr != "api.stormforger.com:443" {
-      return c, nil
-    } else {
-      connstate := c.ConnectionState()
-      keyPinValid := false
-      for _, peercert := range connstate.PeerCertificates {
-        der, err := x509.MarshalPKIXPublicKey(peercert.PublicKey)
-        hash := sha256.Sum256(der)
-        // log.Println(peercert.Issuer)
-        // log.Printf("%#v\n\n", hash)
-        if err != nil {
-          log.Fatal(err)
-        }
-        if bytes.Compare(hash[0:], fingerprint) == 0 {
-          // log.Println("Pinned Key found")
-          keyPinValid = true
-        }
-      }
-      if keyPinValid == false {
-        log.Fatal("TLS Public Key could not be verified!")
-      }
-      return c, nil
-    }
-  }
+		if addr != "api.stormforger.com:443" {
+			return c, nil
+		} else {
+			connstate := c.ConnectionState()
+			keyPinValid := false
+			for _, peercert := range connstate.PeerCertificates {
+				der, err := x509.MarshalPKIXPublicKey(peercert.PublicKey)
+				hash := sha256.Sum256(der)
+				// log.Println(peercert.Issuer)
+				// log.Printf("%#v\n\n", hash)
+				if err != nil {
+					log.Fatal(err)
+				}
+				if bytes.Compare(hash[0:], fingerprint) == 0 {
+					// log.Println("Pinned Key found")
+					keyPinValid = true
+				}
+			}
+			if keyPinValid == false {
+				log.Fatal("TLS Public Key could not be verified!")
+			}
+			return c, nil
+		}
+	}
 }
 
 func defaultHTTPClient() *http.Client {

--- a/api/client.go
+++ b/api/client.go
@@ -30,26 +30,31 @@ func newDialer(fingerprint []byte, skipCAVerification bool) dialer {
 		if err != nil {
 			return c, err
 		}
-		connstate := c.ConnectionState()
-		keyPinValid := false
-		for _, peercert := range connstate.PeerCertificates {
-			der, err := x509.MarshalPKIXPublicKey(peercert.PublicKey)
-			hash := sha256.Sum256(der)
-			// log.Println(peercert.Issuer)
-			// log.Printf("%#v\n\n", hash)
-			if err != nil {
-				log.Fatal(err)
-			}
-			if bytes.Compare(hash[0:], fingerprint) == 0 {
-				// log.Println("Pinned Key found")
-				keyPinValid = true
-			}
-		}
-		if keyPinValid == false {
-			log.Fatal("TLS Public Key could not be verified!")
-		}
-		return c, nil
-	}
+
+    if addr != "api.stormforger.com:443" {
+      return c, nil
+    } else {
+      connstate := c.ConnectionState()
+      keyPinValid := false
+      for _, peercert := range connstate.PeerCertificates {
+        der, err := x509.MarshalPKIXPublicKey(peercert.PublicKey)
+        hash := sha256.Sum256(der)
+        // log.Println(peercert.Issuer)
+        // log.Printf("%#v\n\n", hash)
+        if err != nil {
+          log.Fatal(err)
+        }
+        if bytes.Compare(hash[0:], fingerprint) == 0 {
+          // log.Println("Pinned Key found")
+          keyPinValid = true
+        }
+      }
+      if keyPinValid == false {
+        log.Fatal("TLS Public Key could not be verified!")
+      }
+      return c, nil
+    }
+  }
 }
 
 func defaultHTTPClient() *http.Client {


### PR DESCRIPTION
## What changed & Why

With a recent change to the way we serve File Fixtures (see ) the CLI is supposed to download the File from S3.

The forge CLI does perform a fingerprint check against all certificates and denies the request if the expected fingerprint is not present in the certificate chain.

This causes all File Fixture downloads in all existing CLI clients to fail:

```sh
forge ds get foo test_user.csv
2021/03/26 15:55:09 TLS Public Key could not be verified!
```