### PR TITLE
fix: Enable compression for all api requests to fix datasource downlodas being compressed

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -61,11 +61,10 @@ func defaultHTTPClient() *http.Client {
 	fingerprint := []byte{0x5b, 0x15, 0x6c, 0xda, 0x7b, 0xc3, 0xd, 0x8b, 0xe8, 0x88, 0x57, 0x75, 0xbc, 0x30, 0xc1, 0x84, 0x18, 0x75, 0x6f, 0x2d, 0x3b, 0x81, 0x91, 0xff, 0x34, 0x10, 0xda, 0x13, 0x4a, 0x83, 0x23, 0x9d}
 
 	tr := &http.Transport{
-		MaxIdleConns:       10,
-		IdleConnTimeout:    30 * time.Second,
-		DisableCompression: true,
-		DialTLS:            newDialer(fingerprint, false),
-		Proxy:              http.ProxyURL(getHTTPProxy()),
+		MaxIdleConns:    10,
+		IdleConnTimeout: 30 * time.Second,
+		DialTLS:         newDialer(fingerprint, false),
+		Proxy:           http.ProxyURL(getHTTPProxy()),
 	}
 
 	return &http.Client{

--- a/api/testrun.go
+++ b/api/testrun.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"bytes"
-	"compress/gzip"
 	"errors"
 	"io"
 	"io/ioutil"
@@ -131,8 +130,6 @@ func (c *Client) TestRunLogs(path string) (io.ReadCloser, error) {
 		return nil, err
 	}
 
-	req.Header.Set("Accept-Encoding", "gzip")
-
 	response, err := c.doRequestRaw(req)
 	if err != nil {
 		return nil, err
@@ -145,18 +142,7 @@ func (c *Client) TestRunLogs(path string) (io.ReadCloser, error) {
 		}
 		return nil, errors.New("could not download log")
 	}
-
-	var reader io.ReadCloser
-	switch response.Header.Get("Content-Encoding") {
-	case "gzip":
-		reader, err = gzip.NewReader(response.Body)
-		if err != nil {
-			return nil, err
-		}
-	default:
-		reader = response.Body
-	}
-	return reader, nil
+	return response.Body, nil
 }
 
 // TestRunDump will fetch a traffic dump for a
@@ -171,8 +157,6 @@ func (c *Client) TestRunDump(pathID string) (io.ReadCloser, error) {
 		return nil, err
 	}
 
-	req.Header.Set("Accept-Encoding", "gzip")
-
 	response, err := c.doRequestRaw(req)
 	if err != nil {
 		response.Body.Close()
@@ -183,19 +167,7 @@ func (c *Client) TestRunDump(pathID string) (io.ReadCloser, error) {
 		response.Body.Close()
 		return nil, errors.New("could not load full dump")
 	}
-
-	var reader io.ReadCloser
-	switch response.Header.Get("Content-Encoding") {
-	case "gzip":
-		reader, err = gzip.NewReader(response.Body)
-		if err != nil {
-			return nil, err
-		}
-	default:
-		reader = response.Body
-	}
-
-	return reader, nil
+	return response.Body, nil
 }
 
 // TestRunCreate will send a test case definition (JS) to the API


### PR DESCRIPTION
### Why?

Alternative to #219. With some recent StormForger API changes datasource files are now served gzip compressed. This breaks `ds get <org> <name>`, since compression support was disabled in the HTTP client.

### What?

* Enable compression support in the Go HTTP client so every response with compressed is handled transparently
* Remove manual gzip decompression in the `tc logs/dump` subcommands / api calls

### Notes

@tisba Do you remember why this was disabled before?