### PR TITLE
Update to Go 1.16 and update GHA Workflows

### DIFF
--- a/.github/workflows/gobuild.yml
+++ b/.github/workflows/gobuild.yml
@@ -6,20 +6,25 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-
-    - name: Set up Go 1.15
-      uses: actions/setup-go@v2.1.3
-      with:
-        go-version: 1.15
-      id: go
-
-    - name: Check out code into the Go module directory
+    - name: Check out code
       uses: actions/checkout@v2.3.4
 
+    - name: Read Go version
+      id: read_versions
+      run: |
+        echo "::set-output name=go::$(go mod edit -json | jq -r .Go)"
+
+    - name: Set up Go
+      uses: actions/setup-go@v2.1.3
+      with:
+        go-version: "${{ steps.read_versions.outputs.go }}"
+      id: go
 
     - uses: actions/cache@v2.1.4
       with:
-        path: ~/go/pkg/mod
+        path: |
+          ~/go/pkg/mod
+          ~/.cache/go-build
         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
         restore-keys: |
           ${{ runner.os }}-go-
@@ -28,27 +33,40 @@ jobs:
       run: go version
 
     - name: Build
-      run: go build -v -mod=readonly .
+      run: go build -v .
 
     - name: Test
-      run: go test -timeout 20m -mod=readonly ./...
+      run: go test -timeout 20m ./...
 
     - name: Vet
-      run: go vet -mod=readonly ./...
+      run: go vet ./...
 
   gofmt:
     name: Run gofmt
     runs-on: ubuntu-latest
     steps:
-
-    - name: Set up Go 1.15
-      uses: actions/setup-go@v2.1.3
-      with:
-        go-version: 1.15
-      id: go
-
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2.3.4
+
+    - name: Read go version
+      id: read_versions
+      run: |
+        echo "::set-output name=go::$(go mod edit -json | jq -r .Go)"
+
+    - name: Set up Go
+      uses: actions/setup-go@v2.1.3
+      with:
+        go-version: "${{ steps.read_versions.outputs.go }}"
+      id: go
+
+    - uses: actions/cache@v2.1.4
+      with:
+        path: |
+          ~/go/pkg/mod
+          ~/.cache/go-build
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
 
     - name: gofmt
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,16 +10,28 @@ jobs:
     runs-on: ubuntu-latest
     name: goreleaser
     steps:
-    - name: Set up Go 1.15
+    - name: Check out code
+      uses: actions/checkout@v2.3.4
+
+    - name: Read Go version
+      id: read_versions
+      run: |
+        echo "::set-output name=go::$(go mod edit -json | jq -r .Go)"
+
+    - name: Set up Go
       uses: actions/setup-go@v2.1.3
       with:
-        go-version: 1.15
+        go-version: "${{ steps.read_versions.outputs.go }}"
       id: go
 
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v2.3.4
+    - uses: actions/cache@v2.1.4
       with:
-        fetch-depth: 0
+        path: |
+          ~/go/pkg/mod
+          ~/.cache/go-build
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
 
     - name: 'Wait for status checks'
       uses: jitterbit/await-check-suites@v1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/stormforger/cli
 
-go 1.12
+go 1.16
 
 require (
 	github.com/dustin/go-humanize v1.0.0


### PR DESCRIPTION
This PR updates the CLI to use Go 1.16. I decided to give this a try, because I was looking into releasing [arm64 builds](https://github.com/stormforger/cli/pull/224).

* switch to reading go version from `go.mod`
* added `~/.cache/go-build` to cache paths (see [here](https://github.com/mvdan/github-actions-golang) for an interesting overview)
* remove unneeded `-mod=readonly` as this is the default for Go 1.16 anyway