### PR TITLE
Fix GitHub Action caching issues

### DIFF
--- a/.github/workflows/gobuild.yml
+++ b/.github/workflows/gobuild.yml
@@ -59,15 +59,6 @@ jobs:
         go-version: "${{ steps.read_versions.outputs.go }}"
       id: go
 
-    - uses: actions/cache@v2.1.4
-      with:
-        path: |
-          ~/go/pkg/mod
-          ~/.cache/go-build
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go-
-
     - name: gofmt
       run: |
         if [ "$(find . -iname '*.go' | xargs gofmt -l)" ]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,13 @@ jobs:
     runs-on: ubuntu-latest
     name: goreleaser
     steps:
+    - name: 'Wait for status checks'
+      uses: jitterbit/await-check-suites@v1
+      with:
+        token: "${{ secrets.GITHUB_TOKEN }}"
+        timeoutSeconds: 600
+        appSlugFilter: 'github-actions'
+
     - name: Check out code
       uses: actions/checkout@v2.3.4
 
@@ -32,13 +39,6 @@ jobs:
         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
         restore-keys: |
           ${{ runner.os }}-go-
-
-    - name: 'Wait for status checks'
-      uses: jitterbit/await-check-suites@v1
-      with:
-        token: "${{ secrets.GITHUB_TOKEN }}"
-        timeoutSeconds: 600
-        appSlugFilter: 'github-actions'
 
     - name: Build and push Docker images
       run: docker login -u="${{ secrets.DOCKER_USERNAME }}" -p="${{ secrets.DOCKER_PASSWORD }}"


### PR DESCRIPTION
I noticed that we do have cache hits with very small or even empty caches:

![CleanShot 2021-04-06 at 18 25 55](https://user-images.githubusercontent.com/75156/114384824-83df2500-9b8f-11eb-9f11-eef9952e7fcc.png)

It turns out, that GitHub action is using only the cache key and the fact that it got a hit for the cache. There is no "paths to cache have changed, let's change the cache" mechanism. We used the `actions/cache` step in a couple of places, where we did not use it afterwards like for `gofmt`. This leads to the problem that this job might run and finish first, and creates an empty cache, which other jobs will lookup and load. 🤦 

A similar problem happens for the release workflow: We used to first setup the cache and then wait for other jobs to finish. That might also lead to similar issues described before. We should wait first for other jobs and then setup everything (including hopefully warm caches).