### PR TITLE
ci: Perform a full clone for the release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,8 @@ jobs:
 
     - name: Check out code
       uses: actions/checkout@v2.3.4
+      with:
+        fetch-depth: 0
 
     - name: Read Go version
       id: read_versions


### PR DESCRIPTION
This allows goreleaser to create a proper changelog from the git history. Without it, the changelog only contains the last commit