### PR TITLE
Add proper command for forge tc build

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,6 +1,6 @@
 # examples
 
-These folders contain a few examples to show how to use the CLI and the DSL with modulisation. See `forge test-case build` for details.
+These folders contain a few examples to show how to use the CLI and the DSL with modulisation. See `forge test-case build --help` for details.
 
 Our [documentation](https://docs.stormforger.com) also has guides for integrating the CLI with various CI/CD systems:
 


### PR DESCRIPTION
The README in the `examples/` folder is intended to point users to various features, e.g. the javascript modularization.  The mentioned command `forge test-case build` by itself does not show the long help text, this requires the `--help` flag.