### PR TITLE
TestCase Launch Cmd: Accept --label key=value args

### DIFF
--- a/api/testrun.go
+++ b/api/testrun.go
@@ -3,6 +3,7 @@ package api
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"log"
@@ -29,6 +30,7 @@ type TestRunLaunchOptions struct {
 	SkipWait              bool
 	DumpTraffic           bool
 	SessionValidationMode bool
+	Labels                map[string]string
 }
 
 // TestRunResources describes infos on a test run
@@ -206,6 +208,10 @@ func (c *Client) TestRunCreate(testCaseUID string, options TestRunLaunchOptions)
 		if f.Value != "" {
 			payload.Add(f.Field, f.Value)
 		}
+	}
+
+	for label, value := range options.Labels {
+		payload.Add(fmt.Sprintf("data[custom_data_fields_attributes][%s]", label), value)
 	}
 
 	// build a multipart request, if we have a javascript_definition to upload

--- a/cmd/testcase_launch.go
+++ b/cmd/testcase_launch.go
@@ -138,6 +138,7 @@ type testRunLaunchCmdOpts struct {
 	SessionValidationMode bool
 	Validate              bool
 	TestRunIDOutputFile   string
+	Labels                map[string]string
 
 	Define map[string]string
 }
@@ -160,6 +161,8 @@ func init() {
 
 	testRunLaunchCmd.Flags().StringVar(&testRunLaunchOpts.JavascriptDefinitionFile, "test-case-file", "", "Update the test-case definition from this file before the launch")
 	testRunLaunchCmd.Flags().StringVar(&testRunLaunchOpts.CheckNFR, "nfr-check-file", "", "Check test result against NFR definition (implies --watch)")
+
+	testRunLaunchCmd.Flags().Var(&pflagutil.KeyValueFlag{Map: &testRunLaunchOpts.Labels}, "label", "Attach one or many labels to a Test Launch.")
 
 	// options for debugging
 	testRunLaunchCmd.Flags().BoolVar(&testRunLaunchOpts.DisableGzip, "disable-gzip", false, "Globally disable gzip")
@@ -200,6 +203,7 @@ func MainTestRunLaunch(client *api.Client, testCaseSpec string, testRunLaunchOpt
 		SkipWait:              testRunLaunchOpts.SkipWait,
 		DumpTraffic:           testRunLaunchOpts.DumpTraffic,
 		SessionValidationMode: testRunLaunchOpts.SessionValidationMode,
+		Labels:                testRunLaunchOpts.Labels,
 	}
 	if testRunLaunchOpts.JavascriptDefinitionFile != "" {
 		bundler := testCaseFileBundler{Defines: testRunLaunchOpts.Define}
@@ -218,6 +222,9 @@ func MainTestRunLaunch(client *api.Client, testCaseSpec string, testRunLaunchOpt
 		launchOptions.DumpTraffic = true
 		launchOptions.ClusterSizing = "preflight"
 	}
+
+	// TODO: Validate label input format
+	launchOptions.Labels = testRunLaunchOpts.Labels
 
 	status, response, err := client.TestRunCreate(testCaseUID, launchOptions)
 	if err != nil {

--- a/cmd/testcase_launch.go
+++ b/cmd/testcase_launch.go
@@ -223,7 +223,6 @@ func MainTestRunLaunch(client *api.Client, testCaseSpec string, testRunLaunchOpt
 		launchOptions.ClusterSizing = "preflight"
 	}
 
-	// TODO: Validate label input format
 	launchOptions.Labels = testRunLaunchOpts.Labels
 
 	status, response, err := client.TestRunCreate(testCaseUID, launchOptions)


### PR DESCRIPTION
**See:** https://trello.com/c/fCrRZ22x/364-labels-metadata

## Why are the changes necessary?

Accepting `--label key=value` args which are stored on a Test Run.