### PR TITLE
fix: panic on test-case launch

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -131,8 +131,11 @@ func newPatchRequest(uri string, params map[string]string) (*http.Request, error
 	}
 
 	req, err := http.NewRequest("PATCH", uri, body)
+	if err != nil {
+		return nil, err
+	}
 	req.Header.Set("Content-Type", writer.FormDataContentType())
-	return req, err
+	return req, nil
 }
 
 // createGZIPFormFile creates a "mime/multipart".Writer header similar to CreateFormFile but with content-encoding=gzip.
@@ -181,7 +184,7 @@ func fileUploadRequest(uri, method string, params url.Values, fileParamName, fil
 		return nil, err
 	}
 	req.Header.Set("Content-Type", writer.FormDataContentType())
-	return req, err
+	return req, nil
 }
 
 func (c *Client) addDefaultHeaders(request *http.Request) {

--- a/api/client.go
+++ b/api/client.go
@@ -171,12 +171,15 @@ func fileUploadRequest(uri, method string, params url.Values, fileParamName, fil
 			_ = writer.WriteField(key, value)
 		}
 	}
-	err = writer.Close()
-	if err != nil {
+
+	if err := writer.Close(); err != nil {
 		return nil, err
 	}
 
 	req, err := http.NewRequest(method, uri, body)
+	if err != nil {
+		return nil, err
+	}
 	req.Header.Set("Content-Type", writer.FormDataContentType())
 	return req, err
 }


### PR DESCRIPTION
## Context

User reported a panic in `forge test-case launch` with a module file.

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x38 pc=0x8f8685]
goroutine 1 [running]:
github.com/stormforger/cli/api.fileUploadRequest(0xc0002f6280, 0x45, 0xab3373, 0x4, 0xc000135488, 0xacba52, 0x27, 0x7ffe761fb44d, 0x17, 0xabf638, ...)
	/home/runner/work/cli/cli/api/client.go:180 +0x3c5
github.com/stormforger/cli/api.(*Client).TestRunCreate(0xc000034800, 0x7ffe761fb41e, 0x14, 0x7ffe761fb47e, 0x10, 0x7ffe761fb497, 0x18, 0x7ffe761fb44d, 0x17, 0xb85720, ...)
	/home/runner/work/cli/cli/api/testrun.go:221 +0x716
github.com/stormforger/cli/cmd.MainTestRunLaunch(0xc000034800, 0x7ffe761fb41e, 0x14, 0x0, 0x7ffe761fb47e, 0x10, 0x7ffe761fb497, 0x18, 0x7ffe761fb444, 0x20, ...)
	/home/runner/work/cli/cli/cmd/testcase_launch.go:228 +0x1f8
github.com/stormforger/cli/cmd.glob..func16(0xe672e0, 0xc00010a380, 0x1, 0x8)
	/home/runner/work/cli/cli/cmd/testcase_launch.go:85 +0x7a
github.com/spf13/cobra.(*Command).execute(0xe672e0, 0xc00010a300, 0x8, 0x8, 0xe672e0, 0xc00010a300)
	/home/runner/go/pkg/mod/github.com/spf13/cobra@v1.1.3/command.go:856 +0x2c2
github.com/spf13/cobra.(*Command).ExecuteC(0xe63e60, 0x8, 0x0, 0x0)
	/home/runner/go/pkg/mod/github.com/spf13/cobra@v1.1.3/command.go:960 +0x375
github.com/spf13/cobra.(*Command).Execute(...)
	/home/runner/go/pkg/mod/github.com/spf13/cobra@v1.1.3/command.go:897
github.com/stormforger/cli/cmd.Execute()
	/home/runner/work/cli/cli/cmd/root.go:52 +0x65
main.main()
	/home/runner/work/cli/cli/main.go:8 +0x25
```

## Analysis

I was unable to reproduce the problem but noticed we are not doing any error checking when constructing the request. 
Generally I think the `body` parameter to `http.NewRequest(method, url, body)` must be the problem, as the other two parameters are rather static.

This PR should show the user at least a proper error, even though we will need to do some better error handling in the future.