### PR TITLE
Add archive/unarchive commands for test cases and test runs

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -214,7 +214,7 @@ func (c *Client) doRequest(request *http.Request) (bool, []byte, error) {
 	}
 	defer response.Body.Close()
 
-	body, err := ioutil.ReadAll(response.Body)
+	body, err := io.ReadAll(response.Body)
 	if err != nil {
 		return false, nil, err
 	}

--- a/api/client.go
+++ b/api/client.go
@@ -241,6 +241,22 @@ func (c *Client) fetch(path string) (bool, []byte, error) {
 	return true, body, nil
 }
 
+func (c *Client) put(path string) (int, error) {
+	// TODO
+	req, err := http.NewRequest("PUT", c.APIEndpoint+path, nil)
+	if err != nil {
+		return 0, err
+	}
+
+	response, err := c.doRequestRaw(req)
+	if err != nil {
+		return response.StatusCode, err
+	}
+	defer response.Body.Close()
+
+	return response.StatusCode, nil
+}
+
 func close(c io.Closer) {
 	err := c.Close()
 	if err != nil {

--- a/api/client.go
+++ b/api/client.go
@@ -207,23 +207,8 @@ func (c *Client) doRequestRaw(request *http.Request) (*http.Response, error) {
 	return response, nil
 }
 
-// LookupAndFetchResource tries to download a given resource from the API
-func (c *Client) LookupAndFetchResource(resourceType, input string) (bool, []byte, error) {
-	return c.FetchResource("/lookup?type=" + resourceType + "&q=" + input)
-}
-
-// FetchResource tries to download a given resource from the API
-func (c *Client) FetchResource(path string) (bool, []byte, error) {
-	return c.fetch(path)
-}
-
-func (c *Client) fetch(path string) (bool, []byte, error) {
-	req, err := http.NewRequest("GET", c.APIEndpoint+path, nil)
-	if err != nil {
-		return false, nil, err
-	}
-
-	response, err := c.doRequestRaw(req)
+func (c *Client) doRequest(request *http.Request) (bool, []byte, error) {
+	response, err := c.doRequestRaw(request)
 	if err != nil {
 		return false, nil, err
 	}
@@ -241,20 +226,32 @@ func (c *Client) fetch(path string) (bool, []byte, error) {
 	return true, body, nil
 }
 
-func (c *Client) put(path string) (int, error) {
-	// TODO
-	req, err := http.NewRequest("PUT", c.APIEndpoint+path, nil)
+// LookupAndFetchResource tries to download a given resource from the API
+func (c *Client) LookupAndFetchResource(resourceType, input string) (bool, []byte, error) {
+	return c.FetchResource("/lookup?type=" + resourceType + "&q=" + input)
+}
+
+// FetchResource tries to download a given resource from the API
+func (c *Client) FetchResource(path string) (bool, []byte, error) {
+	return c.fetch(path)
+}
+
+func (c *Client) fetch(path string) (bool, []byte, error) {
+	req, err := http.NewRequest("GET", c.APIEndpoint+path, nil)
 	if err != nil {
-		return 0, err
+		return false, nil, err
 	}
 
-	response, err := c.doRequestRaw(req)
-	if err != nil {
-		return response.StatusCode, err
-	}
-	defer response.Body.Close()
+	return c.doRequest(req)
+}
 
-	return response.StatusCode, nil
+func (c *Client) put(path string, body []byte) (bool, []byte, error) {
+	req, err := http.NewRequest("PUT", c.APIEndpoint+path, bytes.NewReader(body))
+	if err != nil {
+		return false, nil, err
+	}
+
+	return c.doRequest(req)
 }
 
 func close(c io.Closer) {

--- a/api/client.go
+++ b/api/client.go
@@ -8,7 +8,6 @@ import (
 	"crypto/x509"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"mime/multipart"
 	"net"

--- a/api/testcase.go
+++ b/api/testcase.go
@@ -123,7 +123,6 @@ func (c *Client) TestCaseUpdate(testCaseUID string, fileName string, data io.Rea
 
 // TestCaseArchive will mark a test case as archived
 func (c *Client) TestCaseArchive(uid string) (bool, []byte, error) {
-	// TODO
 	path := "/test_cases/" + uid + "/archive"
 
 	return c.put(path, nil)
@@ -132,7 +131,6 @@ func (c *Client) TestCaseArchive(uid string) (bool, []byte, error) {
 
 // TestCaseUnArchive will mark a test case as not archived
 func (c *Client) TestCaseUnArchive(uid string) (bool, []byte, error) {
-	// TODO
 	path := "/test_cases/" + uid + "/unarchive"
 
 	return c.put(path, nil)
@@ -147,9 +145,3 @@ func (c *Client) DownloadTestCaseDefinition(uid string) (bool, []byte, error) {
 	return c.fetch(path)
 }
 
-// testCaseArchived returns true if a test case is archived, false if not
-// The returned error will be nil unless an error occurs during the api request
-func (c *Client) testCaseArchived(uid string) (bool, error) {
-	// TODO
-	return true, nil
-}

--- a/api/testcase.go
+++ b/api/testcase.go
@@ -121,6 +121,18 @@ func (c *Client) TestCaseUpdate(testCaseUID string, fileName string, data io.Rea
 	return true, string(body), nil
 }
 
+// TestCaseArchive will mark a test case as archived
+func (c *Client) TestCaseArchive(uid string) bool {
+	// TODO
+	return true
+}
+
+// TestCaseUnArchive will mark a test case as not archived
+func (c *Client) TestCaseUnArchive(uid string) bool {
+	// TODO
+	return true
+}
+
 // DownloadTestCaseDefinition returns the JS definition
 // of a given test case
 func (c *Client) DownloadTestCaseDefinition(uid string) (bool, []byte, error) {

--- a/api/testcase.go
+++ b/api/testcase.go
@@ -122,35 +122,21 @@ func (c *Client) TestCaseUpdate(testCaseUID string, fileName string, data io.Rea
 }
 
 // TestCaseArchive will mark a test case as archived
-func (c *Client) TestCaseArchive(uid string) (bool, error) {
+func (c *Client) TestCaseArchive(uid string) (bool, []byte, error) {
 	// TODO
 	path := "/test_cases/" + uid + "/archive"
 
-	code, err := c.put(path)
-	if err != nil {
-		return false, err
-	}
+	return c.put(path, nil)
 
-	if code == 200 {
-		return true, nil
-	}
-	return false, nil
 }
 
 // TestCaseUnArchive will mark a test case as not archived
-func (c *Client) TestCaseUnArchive(uid string) (bool, error) {
+func (c *Client) TestCaseUnArchive(uid string) (bool, []byte, error) {
 	// TODO
 	path := "/test_cases/" + uid + "/unarchive"
 
-	code, err := c.put(path)
-	if err != nil {
-		return false, err
-	}
+	return c.put(path, nil)
 
-	if code == 200 {
-		return true, nil
-	}
-	return false, nil
 }
 
 // DownloadTestCaseDefinition returns the JS definition

--- a/api/testcase.go
+++ b/api/testcase.go
@@ -1,10 +1,8 @@
 package api
 
 import (
-	"fmt"
 	"io"
 	"io/ioutil"
-	"net/http"
 	"net/url"
 )
 
@@ -128,26 +126,31 @@ func (c *Client) TestCaseArchive(uid string) (bool, error) {
 	// TODO
 	path := "/test_cases/" + uid + "/archive"
 
-	req, err := http.NewRequest("PUT", c.APIEndpoint+path, nil)
+	code, err := c.put(path)
 	if err != nil {
 		return false, err
 	}
 
-	response, err := c.doRequestRaw(req)
-	if err != nil {
-		return false, err
+	if code == 200 {
+		return true, nil
 	}
-	defer response.Body.Close()
-
-	fmt.Println("Response code: ", response.StatusCode)
-
-	return true, nil
+	return false, nil
 }
 
 // TestCaseUnArchive will mark a test case as not archived
 func (c *Client) TestCaseUnArchive(uid string) (bool, error) {
 	// TODO
-	return true, nil
+	path := "/test_cases/" + uid + "/unarchive"
+
+	code, err := c.put(path)
+	if err != nil {
+		return false, err
+	}
+
+	if code == 200 {
+		return true, nil
+	}
+	return false, nil
 }
 
 // DownloadTestCaseDefinition returns the JS definition

--- a/api/testcase.go
+++ b/api/testcase.go
@@ -144,4 +144,3 @@ func (c *Client) DownloadTestCaseDefinition(uid string) (bool, []byte, error) {
 
 	return c.fetch(path)
 }
-

--- a/api/testcase.go
+++ b/api/testcase.go
@@ -1,8 +1,10 @@
 package api
 
 import (
+	"fmt"
 	"io"
 	"io/ioutil"
+	"net/http"
 	"net/url"
 )
 
@@ -122,15 +124,30 @@ func (c *Client) TestCaseUpdate(testCaseUID string, fileName string, data io.Rea
 }
 
 // TestCaseArchive will mark a test case as archived
-func (c *Client) TestCaseArchive(uid string) bool {
+func (c *Client) TestCaseArchive(uid string) (bool, error) {
 	// TODO
-	return true
+	path := "/test_cases/" + uid + "/archive"
+
+	req, err := http.NewRequest("PUT", c.APIEndpoint+path, nil)
+	if err != nil {
+		return false, err
+	}
+
+	response, err := c.doRequestRaw(req)
+	if err != nil {
+		return false, err
+	}
+	defer response.Body.Close()
+
+	fmt.Println("Response code: ", response.StatusCode)
+
+	return true, nil
 }
 
 // TestCaseUnArchive will mark a test case as not archived
-func (c *Client) TestCaseUnArchive(uid string) bool {
+func (c *Client) TestCaseUnArchive(uid string) (bool, error) {
 	// TODO
-	return true
+	return true, nil
 }
 
 // DownloadTestCaseDefinition returns the JS definition
@@ -139,4 +156,11 @@ func (c *Client) DownloadTestCaseDefinition(uid string) (bool, []byte, error) {
 	path := "/test_cases/" + uid + "/download"
 
 	return c.fetch(path)
+}
+
+// testCaseArchived returns true if a test case is archived, false if not
+// The returned error will be nil unless an error occurs during the api request
+func (c *Client) testCaseArchived(uid string) (bool, error) {
+	// TODO
+	return true, nil
 }

--- a/api/testrun.go
+++ b/api/testrun.go
@@ -324,15 +324,19 @@ func (c *Client) TestRunNfrCheck(uid string, fileName string, data io.Reader) (b
 }
 
 // TestRunArchive marks a given test run as archived.
-func (c *Client) TestRunArchive(uid string) bool {
+func (c *Client) TestRunArchive(testRunUID string) (bool, []byte, error) {
 	// TODO
-	return true
+	path := "/test_runs/" + testRunUID + "/archive"
+
+	return c.put(path, nil)
 }
 
 // TestRunUnArchive marks a given test run as not archived.
-func (c *Client) TestRunUnArchive(uid string) bool {
+func (c *Client) TestRunUnArchive(testRunUID string) (bool, []byte, error) {
 	// TODO
-	return true
+	path := "/test_runs/" + testRunUID + "/unarchive"
+
+	return c.put(path, nil)
 }
 
 // ExtractTestRunResources will try to extract information to the

--- a/api/testrun.go
+++ b/api/testrun.go
@@ -323,6 +323,18 @@ func (c *Client) TestRunNfrCheck(uid string, fileName string, data io.Reader) (b
 	return response.StatusCode < 400, body, nil
 }
 
+// TestRunArchive marks a given test run as archived.
+func (c *Client) TestRunArchive(uid string) bool {
+	// TODO
+	return true
+}
+
+// TestRunUnArchive marks a given test run as not archived.
+func (c *Client) TestRunUnArchive(uid string) bool {
+	// TODO
+	return true
+}
+
 // ExtractTestRunResources will try to extract information to the
 // given test run based on a "reference".
 //

--- a/api/testrun.go
+++ b/api/testrun.go
@@ -325,7 +325,6 @@ func (c *Client) TestRunNfrCheck(uid string, fileName string, data io.Reader) (b
 
 // TestRunArchive marks a given test run as archived.
 func (c *Client) TestRunArchive(testRunUID string) (bool, []byte, error) {
-	// TODO
 	path := "/test_runs/" + testRunUID + "/archive"
 
 	return c.put(path, nil)
@@ -333,7 +332,6 @@ func (c *Client) TestRunArchive(testRunUID string) (bool, []byte, error) {
 
 // TestRunUnArchive marks a given test run as not archived.
 func (c *Client) TestRunUnArchive(testRunUID string) (bool, []byte, error) {
-	// TODO
 	path := "/test_runs/" + testRunUID + "/unarchive"
 
 	return c.put(path, nil)

--- a/cmd/testcase_archive.go
+++ b/cmd/testcase_archive.go
@@ -10,14 +10,14 @@ var (
 	// testCaseArchiveCmd represents the test case archive command
 	testCaseArchiveCmd = &cobra.Command{
 		Use:     "archive <test-case-ref>",
-		Aliases: []string{},
-		Short:   "Mark a test case as archived",
+		Aliases: []string{"ar", "a"},
+		Short:   "Archive a test case.",
 		Long: `Mark the specified test case as archived"
 
 <test-case-ref> can be 'organisation-name/test-case-name' or 'test-case-uid'.
 `,
-		Run:               runTestCaseArchive,
-		PersistentPreRun:  func(cmd *cobra.Command, args []string) {
+		Run: runTestCaseArchive,
+		PersistentPreRun: func(cmd *cobra.Command, args []string) {
 			if len(args) < 1 {
 				log.Fatal("Missing argument: test case reference")
 			}
@@ -40,12 +40,12 @@ func runTestCaseArchive(cmd *cobra.Command, args []string) {
 
 	testCaseUID := mustLookupTestCase(client, args[0])
 
-	success, err := client.TestCaseArchive(testCaseUID)
+	success, response, err := client.TestCaseArchive(testCaseUID)
 	if err != nil {
 		log.Fatal(err)
 	}
 
 	if !success {
-		log.Fatalf("Test case definition could not be archived.\n")
+		log.Fatalf("Test case definition could not be archived!\n%s\n", string(response))
 	}
 }

--- a/cmd/testcase_archive.go
+++ b/cmd/testcase_archive.go
@@ -1,6 +1,10 @@
 package cmd
 
-import "github.com/spf13/cobra"
+import (
+	"log"
+
+	"github.com/spf13/cobra"
+)
 
 var (
 	// testCaseArchiveCmd represents the test case archive command
@@ -24,4 +28,16 @@ func init() {
 
 func runTestCaseArchive(cmd *cobra.Command, args []string) {
 	// TODO
+	client := NewClient()
+
+	testCaseUID := mustLookupTestCase(client, args[0])
+
+	success, err := client.TestCaseArchive(testCaseUID)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if !success {
+		log.Fatalf("Test case definition could not be archived.\n")
+	}
 }

--- a/cmd/testcase_archive.go
+++ b/cmd/testcase_archive.go
@@ -17,7 +17,15 @@ var (
 <test-case-ref> can be 'organisation-name/test-case-name' or 'test-case-uid'.
 `,
 		Run:               runTestCaseArchive,
-		PersistentPreRun:  nil, // TODO
+		PersistentPreRun:  func(cmd *cobra.Command, args []string) {
+			if len(args) < 1 {
+				log.Fatal("Missing argument: test case reference")
+			}
+
+			if len(args) > 2 {
+				log.Fatal("Too many arguments")
+			}
+		},
 		ValidArgsFunction: completeOrgaAndCase,
 	}
 )

--- a/cmd/testcase_archive.go
+++ b/cmd/testcase_archive.go
@@ -35,7 +35,6 @@ func init() {
 }
 
 func runTestCaseArchive(cmd *cobra.Command, args []string) {
-	// TODO
 	client := NewClient()
 
 	testCaseUID := mustLookupTestCase(client, args[0])

--- a/cmd/testcase_archive.go
+++ b/cmd/testcase_archive.go
@@ -1,0 +1,27 @@
+package cmd
+
+import "github.com/spf13/cobra"
+
+var (
+	// testCaseArchiveCmd represents the test case archive command
+	testCaseArchiveCmd = &cobra.Command{
+		Use: "archive <test-case-ref>",
+		Aliases: []string{},
+		Short: "Mark a test case as archived",
+		Long: `Mark the specified test case as archived"
+
+<test-case-ref> can be 'organisation-name/test-case-name' or 'test-case-uid'.
+`,
+		Run: runTestCaseArchive,
+		PersistentPreRun: nil, // TODO
+		ValidArgsFunction: completeOrgaAndCase,
+	}
+)
+
+func init() {
+	TestCaseCmd.AddCommand(testCaseArchiveCmd)
+}
+
+func runTestCaseArchive(cmd *cobra.Command, args []string) {
+	// TODO
+}

--- a/cmd/testcase_archive.go
+++ b/cmd/testcase_archive.go
@@ -5,15 +5,15 @@ import "github.com/spf13/cobra"
 var (
 	// testCaseArchiveCmd represents the test case archive command
 	testCaseArchiveCmd = &cobra.Command{
-		Use: "archive <test-case-ref>",
+		Use:     "archive <test-case-ref>",
 		Aliases: []string{},
-		Short: "Mark a test case as archived",
+		Short:   "Mark a test case as archived",
 		Long: `Mark the specified test case as archived"
 
 <test-case-ref> can be 'organisation-name/test-case-name' or 'test-case-uid'.
 `,
-		Run: runTestCaseArchive,
-		PersistentPreRun: nil, // TODO
+		Run:               runTestCaseArchive,
+		PersistentPreRun:  nil, // TODO
 		ValidArgsFunction: completeOrgaAndCase,
 	}
 )

--- a/cmd/testcase_unarchive.go
+++ b/cmd/testcase_unarchive.go
@@ -5,7 +5,7 @@ import "github.com/spf13/cobra"
 var (
 	// testCaseArchiveCmd represents the test case archive command
 	testCaseUnArchiveCmd = &cobra.Command{
-		Use:     "archive <test-case-ref>",
+		Use:     "unarchive <test-case-ref>",
 		Aliases: []string{},
 		Short:   "Mark a test case as not archived",
 		Long: `Mark the specified test case as not archived"

--- a/cmd/testcase_unarchive.go
+++ b/cmd/testcase_unarchive.go
@@ -10,14 +10,14 @@ var (
 	// testCaseUnArchiveCmd represents the test case unarchive command
 	testCaseUnArchiveCmd = &cobra.Command{
 		Use:     "unarchive <test-case-ref>",
-		Aliases: []string{},
-		Short:   "Mark a test case as not archived",
+		Aliases: []string{"unar", "ua"},
+		Short:   "Unarchive a test case.",
 		Long: `Mark the specified test case as not archived"
 
 <test-case-ref> can be 'organisation-name/test-case-name' or 'test-case-uid'.
 `,
-		Run:               runTestCaseUnArchive,
-		PersistentPreRun:  func(cmd *cobra.Command, args []string) {
+		Run: runTestCaseUnArchive,
+		PersistentPreRun: func(cmd *cobra.Command, args []string) {
 			if len(args) < 1 {
 				log.Fatal("Missing argument: test case reference")
 			}
@@ -40,12 +40,12 @@ func runTestCaseUnArchive(cmd *cobra.Command, args []string) {
 
 	testCaseUID := mustLookupTestCase(client, args[0])
 
-	success, err := client.TestCaseUnArchive(testCaseUID)
+	success, response, err := client.TestCaseUnArchive(testCaseUID)
 	if err != nil {
 		log.Fatal(err)
 	}
 
 	if !success {
-		log.Fatalf("Test case definition could not be unarchived.\n")
+		log.Fatalf("Test case definition could not be unarchived!\n%s\n", string(response))
 	}
 }

--- a/cmd/testcase_unarchive.go
+++ b/cmd/testcase_unarchive.go
@@ -35,7 +35,6 @@ func init() {
 }
 
 func runTestCaseUnArchive(cmd *cobra.Command, args []string) {
-	// TODO
 	client := NewClient()
 
 	testCaseUID := mustLookupTestCase(client, args[0])

--- a/cmd/testcase_unarchive.go
+++ b/cmd/testcase_unarchive.go
@@ -1,9 +1,13 @@
 package cmd
 
-import "github.com/spf13/cobra"
+import (
+	"log"
+
+	"github.com/spf13/cobra"
+)
 
 var (
-	// testCaseArchiveCmd represents the test case archive command
+	// testCaseUnArchiveCmd represents the test case unarchive command
 	testCaseUnArchiveCmd = &cobra.Command{
 		Use:     "unarchive <test-case-ref>",
 		Aliases: []string{},
@@ -13,7 +17,15 @@ var (
 <test-case-ref> can be 'organisation-name/test-case-name' or 'test-case-uid'.
 `,
 		Run:               runTestCaseUnArchive,
-		PersistentPreRun:  nil, // TODO
+		PersistentPreRun:  func(cmd *cobra.Command, args []string) {
+			if len(args) < 1 {
+				log.Fatal("Missing argument: test case reference")
+			}
+
+			if len(args) > 2 {
+				log.Fatal("Too many arguments")
+			}
+		},
 		ValidArgsFunction: completeOrgaAndCase,
 	}
 )
@@ -24,4 +36,16 @@ func init() {
 
 func runTestCaseUnArchive(cmd *cobra.Command, args []string) {
 	// TODO
+	client := NewClient()
+
+	testCaseUID := mustLookupTestCase(client, args[0])
+
+	success, err := client.TestCaseUnArchive(testCaseUID)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if !success {
+		log.Fatalf("Test case definition could not be unarchived.\n")
+	}
 }

--- a/cmd/testcase_unarchive.go
+++ b/cmd/testcase_unarchive.go
@@ -5,15 +5,15 @@ import "github.com/spf13/cobra"
 var (
 	// testCaseArchiveCmd represents the test case archive command
 	testCaseUnArchiveCmd = &cobra.Command{
-		Use: "archive <test-case-ref>",
+		Use:     "archive <test-case-ref>",
 		Aliases: []string{},
-		Short: "Mark a test case as not archived",
+		Short:   "Mark a test case as not archived",
 		Long: `Mark the specified test case as not archived"
 
 <test-case-ref> can be 'organisation-name/test-case-name' or 'test-case-uid'.
 `,
-		Run: runTestCaseUnArchive,
-		PersistentPreRun: nil, // TODO
+		Run:               runTestCaseUnArchive,
+		PersistentPreRun:  nil, // TODO
 		ValidArgsFunction: completeOrgaAndCase,
 	}
 )

--- a/cmd/testcase_unarchive.go
+++ b/cmd/testcase_unarchive.go
@@ -1,0 +1,27 @@
+package cmd
+
+import "github.com/spf13/cobra"
+
+var (
+	// testCaseArchiveCmd represents the test case archive command
+	testCaseUnArchiveCmd = &cobra.Command{
+		Use: "archive <test-case-ref>",
+		Aliases: []string{},
+		Short: "Mark a test case as not archived",
+		Long: `Mark the specified test case as not archived"
+
+<test-case-ref> can be 'organisation-name/test-case-name' or 'test-case-uid'.
+`,
+		Run: runTestCaseUnArchive,
+		PersistentPreRun: nil, // TODO
+		ValidArgsFunction: completeOrgaAndCase,
+	}
+)
+
+func init() {
+	TestCaseCmd.AddCommand(testCaseUnArchiveCmd)
+}
+
+func runTestCaseUnArchive(cmd *cobra.Command, args []string) {
+	// TODO
+}

--- a/cmd/testrun_archive.go
+++ b/cmd/testrun_archive.go
@@ -30,7 +30,6 @@ func init() {
 }
 
 func testRunArchive(cmd *cobra.Command, args []string) {
-	// TODO
 	client := NewClient()
 
 	testRunUID := getTestRunUID(*client, args[0])

--- a/cmd/testrun_archive.go
+++ b/cmd/testrun_archive.go
@@ -4,10 +4,10 @@ import "github.com/spf13/cobra"
 
 var (
 	testRunArchiveCmd = &cobra.Command{
-		Use: "archive <test-run-ref>",
-		Short: "Mark a test run as archived.",
-		Long: `Mark a test run as archived.`,
-		Run: testRunArchive,
+		Use:              "archive <test-run-ref>",
+		Short:            "Mark a test run as archived.",
+		Long:             `Mark a test run as archived.`,
+		Run:              testRunArchive,
 		PersistentPreRun: nil, // TODO
 
 	}

--- a/cmd/testrun_archive.go
+++ b/cmd/testrun_archive.go
@@ -1,15 +1,27 @@
 package cmd
 
-import "github.com/spf13/cobra"
+import (
+	"log"
+
+	"github.com/spf13/cobra"
+)
 
 var (
 	testRunArchiveCmd = &cobra.Command{
-		Use:              "archive <test-run-ref>",
-		Short:            "Mark a test run as archived.",
-		Long:             `Mark a test run as archived.`,
-		Run:              testRunArchive,
-		PersistentPreRun: nil, // TODO
+		Use:     "archive <test-run-ref>",
+		Aliases: []string{"ar", "a"},
+		Short:   "Mark a test run as archived.",
+		Long:    `Mark a test run as archived.`,
+		Run:     testRunArchive,
+		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			if len(args) < 1 {
+				log.Fatal("Missing argument: test run reference")
+			}
 
+			if len(args) > 2 {
+				log.Fatal("Too many arguments")
+			}
+		},
 	}
 )
 
@@ -19,4 +31,17 @@ func init() {
 
 func testRunArchive(cmd *cobra.Command, args []string) {
 	// TODO
+	client := NewClient()
+
+	testRunUID := getTestRunUID(*client, args[0])
+
+	success, response, err := client.TestRunArchive(testRunUID)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if !success {
+		log.Fatalf("Test run could not be archived!\n%s\n", string(response))
+	}
+
 }

--- a/cmd/testrun_archive.go
+++ b/cmd/testrun_archive.go
@@ -1,0 +1,22 @@
+package cmd
+
+import "github.com/spf13/cobra"
+
+var (
+	testRunArchiveCmd = &cobra.Command{
+		Use: "archive <test-run-ref>",
+		Short: "Mark a test run as archived.",
+		Long: `Mark a test run as archived.`,
+		Run: testRunArchive,
+		PersistentPreRun: nil, // TODO
+
+	}
+)
+
+func init() {
+	TestRunCmd.AddCommand(testRunArchiveCmd)
+}
+
+func testRunArchive(cmd *cobra.Command, args []string) {
+	// TODO
+}

--- a/cmd/testrun_unarchive.go
+++ b/cmd/testrun_unarchive.go
@@ -1,15 +1,27 @@
 package cmd
 
-import "github.com/spf13/cobra"
+import (
+	"log"
+
+	"github.com/spf13/cobra"
+)
 
 var (
 	testRunUnArchiveCmd = &cobra.Command{
-		Use:              "unarchive <test-run-ref>",
-		Short:            "Mark a test run as not archived.",
-		Long:             `Mark a test run as not archived.`,
-		Run:              testRunUnArchive,
-		PersistentPreRun: nil, // TODO
+		Use:     "unarchive <test-run-ref>",
+		Aliases: []string{"unar", "ua"},
+		Short:   "Mark a test run as not archived.",
+		Long:    `Mark a test run as not archived.`,
+		Run:     testRunUnArchive,
+		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			if len(args) < 1 {
+				log.Fatal("Missing argument: test run reference")
+			}
 
+			if len(args) > 2 {
+				log.Fatal("Too many arguments")
+			}
+		},
 	}
 )
 
@@ -19,4 +31,16 @@ func init() {
 
 func testRunUnArchive(cmd *cobra.Command, args []string) {
 	// TODO
+	client := NewClient()
+
+	testRunUID := getTestRunUID(*client, args[0])
+
+	success, response, err := client.TestRunUnArchive(testRunUID)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if !success {
+		log.Fatalf("Test run could not be unarchived!\n%s\n", string(response))
+	}
 }

--- a/cmd/testrun_unarchive.go
+++ b/cmd/testrun_unarchive.go
@@ -1,0 +1,22 @@
+package cmd
+
+import "github.com/spf13/cobra"
+
+var (
+	testRunUnArchiveCmd = &cobra.Command{
+		Use: "unarchive <test-run-ref>",
+		Short: "Mark a test run as not archived.",
+		Long: `Mark a test run as not archived.`,
+		Run: testRunUnArchive,
+		PersistentPreRun: nil, // TODO
+
+	}
+)
+
+func init() {
+	TestRunCmd.AddCommand(testRunUnArchiveCmd)
+}
+
+func testRunUnArchive(cmd *cobra.Command, args []string) {
+	// TODO
+}

--- a/cmd/testrun_unarchive.go
+++ b/cmd/testrun_unarchive.go
@@ -4,10 +4,10 @@ import "github.com/spf13/cobra"
 
 var (
 	testRunUnArchiveCmd = &cobra.Command{
-		Use: "unarchive <test-run-ref>",
-		Short: "Mark a test run as not archived.",
-		Long: `Mark a test run as not archived.`,
-		Run: testRunUnArchive,
+		Use:              "unarchive <test-run-ref>",
+		Short:            "Mark a test run as not archived.",
+		Long:             `Mark a test run as not archived.`,
+		Run:              testRunUnArchive,
 		PersistentPreRun: nil, // TODO
 
 	}

--- a/cmd/testrun_unarchive.go
+++ b/cmd/testrun_unarchive.go
@@ -30,7 +30,6 @@ func init() {
 }
 
 func testRunUnArchive(cmd *cobra.Command, args []string) {
-	// TODO
 	client := NewClient()
 
 	testRunUID := getTestRunUID(*client, args[0])


### PR DESCRIPTION
#### Why?
We can currently archive and unarchive test runs and cases from the web UI, but not via the CLI. This PR will add archive and unarchive commands for test cases and test runs.

#### What?
Adds an `archive` and `unarchive` subcommand to both the test-case and test-run commands. Adds api support to match updates to forge made in https://github.com/stormforger/forge/pull/3592. Also adds a `put` method to the api client that basically matches the existing `fetch` method, but performs an HTTP PUT.

Tested manually against a local forge instance.

#### Caveats
None that I know of.
