### PR TITLE
Update login text

### DIFF
--- a/cmd/login.go
+++ b/cmd/login.go
@@ -73,8 +73,10 @@ func runLogin(cmd *cobra.Command, args []string) {
 		} else {
 			color.White("\nLogin successful!\n\n")
 			color.Red("Found %s. File will not be overridden!\n\n", stormforgerConfig)
-			color.White("Add the JWT token to a .stormforger.toml file like this:\n\n")
-			color.Green("  echo 'jwt = \"" + jwt + "\"' >> ~/.stormforger.toml")
+			color.White("If you wish to use the following authentication token, you can place it in the .stormforger.toml configuration file in your home directory by adding a line like this:\n")
+			color.Blue("jwt = \"<authentication token>\"\n")
+			color.White("Note that if you have multiple jwt entries in your .stormforger.toml, only the first will be used.\n\n")
+			color.Green("Authentication token:\n" + jwt)
 			color.Green("\n\n")
 		}
 	}

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -75,7 +75,8 @@ func runLogin(cmd *cobra.Command, args []string) {
 			color.Red("Found %s. File will not be overridden!\n\n", stormforgerConfig)
 			color.White("If you wish to use the following authentication token, you can place it in the .stormforger.toml configuration file in your home directory by adding a line like this:\n")
 			color.Blue("jwt = \"<authentication token>\"\n")
-			color.White("Note that if you have multiple jwt entries in your .stormforger.toml, only the first will be used.\n\n")
+			color.White("Note that if you have multiple jwt entries in your .stormforger.toml, only the first will be used.\n")
+			fmt.Print(color.WhiteString("Alternatively, you can export the "), color.BlueString("STORMFORGER_JWT"), color.WhiteString(" environment variable with the value of the token for use in CI/CD pipelines, containers, etc.\n\n"))
 			color.Green("Authentication token:\n" + jwt)
 			color.Green("\n\n")
 		}


### PR DESCRIPTION
See: https://trello.com/c/ghpvvMxb
See also: https://stormkore.slack.com/archives/C020D8Q02BB/p1633974941003900

This PR updates the login text that is displayed when a user has an existing `.stormforger.toml` file. Instead of giving the user an `echo` command that can be used to append the JWT to their config file, we now display some simple instructions on how to add the token to the config file. This should ease confusion in cases where users might otherwise blindly append multiple tokens to their config file, and then be confused when only the first token is ever used.