### PR TITLE
tests: Add go tests for the 'forge tc build --define'

### DIFF
--- a/cmd/testcase_build_test.go
+++ b/cmd/testcase_build_test.go
@@ -20,6 +20,31 @@ func TestTestcaseBuild(t *testing.T) {
 	assert.Equal(t, expectedOutput, output.String())
 }
 
+func TestTestcaseBuild__DefineParam(t *testing.T) {
+	var expectedOutput = GivenTestdataContents(t, t.Name()+"_output.js")
+	defines := map[string]string{
+		"ENV": "\"production\"", // DOUBLE QUOTING!
+	}
+
+	var output strings.Builder
+	err := MainTestcaseBuild(&output, filepath.Join("testdata", t.Name()+"_main.mjs"), defines)
+	assert.NoError(t, err)
+
+	assert.Equal(t, expectedOutput, output.String())
+}
+
+// Same input as TestTestcaseBuild__DefineParam but we do NOT specify the define parameter.
+// This must still build without an error
+func TestTestcaseBuild__WithUndefinedVariable(t *testing.T) {
+	var expectedOutput = GivenTestdataContents(t, t.Name()+"_output.js")
+
+	var output strings.Builder
+	err := MainTestcaseBuild(&output, filepath.Join("testdata", t.Name()+"_main.mjs"), nil)
+	assert.NoError(t, err)
+
+	assert.Equal(t, expectedOutput, output.String())
+}
+
 func GivenTestdataContents(t *testing.T, file string) string {
 	p := filepath.Join("testdata", file)
 

--- a/cmd/testdata/TestTestcaseBuild__DefineParam_main.mjs
+++ b/cmd/testdata/TestTestcaseBuild__DefineParam_main.mjs
@@ -1,0 +1,5 @@
+const config = {
+  env: ENV || "staging",
+}
+
+definition.addTarget(env);

--- a/cmd/testdata/TestTestcaseBuild__DefineParam_output.js
+++ b/cmd/testdata/TestTestcaseBuild__DefineParam_output.js
@@ -1,0 +1,2 @@
+// testdata/TestTestcaseBuild__DefineParam_main.mjs
+definition.addTarget(env);

--- a/cmd/testdata/TestTestcaseBuild__WithUndefinedVariable_main.mjs
+++ b/cmd/testdata/TestTestcaseBuild__WithUndefinedVariable_main.mjs
@@ -1,0 +1,5 @@
+const config = {
+  env: ENV || "staging", // Intentionally undefined in the go test
+}
+
+definition.addTarget(env);

--- a/cmd/testdata/TestTestcaseBuild__WithUndefinedVariable_output.js
+++ b/cmd/testdata/TestTestcaseBuild__WithUndefinedVariable_output.js
@@ -1,0 +1,5 @@
+// testdata/TestTestcaseBuild__WithUndefinedVariable_main.mjs
+var config = {
+  env: ENV || "staging"
+};
+definition.addTarget(env);


### PR DESCRIPTION
This PR adds two test cases to verify that `--define` works and generates no error. 

The example script was copied from the help message of `forge tc build --help` [src](https://github.com/stormforger/cli/blob/master/cmd/testcase_build.go#L54-L56) and thus it is important that this case actually works. So lets add a test for it ;)