### PR TITLE
fix: Add hint for .mjs file extension when showing usage warning

### DIFF
--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -112,7 +112,7 @@ func (bundler testCaseFileBundler) Bundle(arg, defaultFileName string) (testCase
 	}
 
 	if len(bundler.Defines) > 0 {
-		log.Println("WARN: --define used with non-module testcase file")
+		log.Println("WARN: --define used with non-module testcase file - missing .mjs file extension")
 	}
 	return testCaseFileBundle{Name: fileName, Content: testCaseFile}, err
 }


### PR DESCRIPTION
An internal user tried using `--define` with his test-case and got this error that confused him:

```terminal
2022/02/07 04:28:13 WARN: --define used with non-module testcase file

<lots of validation / update errors by our API>
```

This changes the warning to hint the user to use the `.mjs` file extension.
