### PR TITLE
Drop scope parameter from test runs as well

### DIFF
--- a/api/testrun/testrun.go
+++ b/api/testrun/testrun.go
@@ -16,7 +16,6 @@ type List struct {
 // TestRun represents a single TestRun
 type TestRun struct {
 	ID                string             `jsonapi:"primary,test_runs"`
-	Scope             string             `jsonapi:"attr,scope"`
 	Title             string             `jsonapi:"attr,title,omitempty"`
 	Notes             string             `jsonapi:"attr,notes,omitempty"`
 	State             string             `jsonapi:"attr,state,omitempty"`

--- a/cmd/testcase_launch.go
+++ b/cmd/testcase_launch.go
@@ -263,11 +263,12 @@ func MainTestRunLaunch(client *api.Client, testCaseSpec string, testRunLaunchOpt
 			fmt.Println("Test-Case successfully updated")
 		}
 
-		fmt.Printf(`Launching test %s
-UID: %s
+		fmt.Printf(`Launching test %s (%s)
+TestRun UID: %s
 Web URL: %s
 `,
-			testRun.Scope,
+			testCaseSpec,
+			testCaseUID,
 			testRun.ID,
 			meta.Links.SelfWeb,
 		)

--- a/cmd/testrun_list.go
+++ b/cmd/testrun_list.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/stormforger/cli/api/testrun"
+	"github.com/stormforger/cli/internal/stringutil"
 )
 
 var (
@@ -79,11 +80,18 @@ func testRunList(cmd *cobra.Command, args []string) {
 		log.Fatal(err)
 	}
 
+	if rootOpts.OutputFormat == "human" {
+		fmt.Println("ID        Started At           Title")
+	}
 	for _, item := range items.TestRuns {
 		if rootOpts.OutputFormat == "human" {
-			fmt.Printf("%s (ID: %s)\n", item.Scope, item.ID)
-		} else {
-			fmt.Printf("%s\n", item.Scope)
+			fmt.Printf("%s  %s %s\n",
+				item.ID,
+				stringutil.Coalesce(item.StartedAt, "<no startet_at date>"),
+				stringutil.Coalesce(item.Title, "<no title>"),
+			)
+		} else { // plain
+			fmt.Printf("%s\n", item.ID)
 		}
 	}
 }

--- a/cmd/testrun_show.go
+++ b/cmd/testrun_show.go
@@ -67,7 +67,7 @@ func testRunShow(cmd *cobra.Command, args []string) {
 		return
 	}
 
-	fmt.Printf("%s (%s, %s)\n", testRun.Scope, testRun.State, testRun.ID)
+	fmt.Printf("ID      %s (%s)\n", testRun.ID, testRun.State)
 	fmt.Printf("Report  %s\n", meta.Links.SelfWeb)
 	if testRun.Title != "" {
 		fmt.Printf("Title   %s\n", testRun.Title)

--- a/internal/stringutil/stringutil.go
+++ b/internal/stringutil/stringutil.go
@@ -23,3 +23,13 @@ func FilterByPrefix(prefix string, list []string) []string {
 
 	return list
 }
+
+// Coalesce returns the first non empty (trimmed) string.
+func Coalesce(a ...string) string {
+	for _, s := range a {
+		if strings.TrimSpace(s) != "" {
+			return s
+		}
+	}
+	return ""
+}


### PR DESCRIPTION
## Motivation

The `Scope` field in the API is currently a joined description of the organisation, test case name and test run sequence.

We want to weaken the usage of the organisation in our outputs + this field may go away.

## Changes

* No longer deserialize the `Scope` field from api responses
* Print UIDs in output instead of scope

## Example Outputs

```terminal
14:27 $ ../cli/cli tc launch demo/demo
Launching test demo/demo (Fk92vcL5)
TestRun UID: wqXx6V5B
Web URL: http://localhost/tr/wqXx6V5B
Configuration: preflight cluster in eu-west-1

14:39 $ ../cli/cli tr ls demo/demo
ID        Started At           Title
oFGf4kBh  2022-03-01T10:05:18Z <no title>
eBeqkPwW  2022-03-01T10:06:08Z <no title>
dJTG2dfD  2022-03-01T10:06:09Z <no title>
nsdS04Qg  <no startet_at date> <no title>
vdhRXQHk  <no startet_at date> <no title>
wqXx6V5B  <no startet_at date> <no title>

14:40 $ ../cli/cli tr show oFGf4kBh
ID      oFGf4kBh (aborted)
Report  http://localhost/tr/oFGf4kBh
Started 2022-03-01T10:05:18Z
Ended   2022-03-01T10:05:44Z
Configuration:
  Setup: preflight cluster in self-hosted
```

## Caveats

This breaks our current `human` output for listing + launching test-runs, but I don't think anyone parses that. We have a `json` variant for that.