### PR TITLE
Ignore 'checks' items as long as the test-run has no checks defined, …

### DIFF
--- a/cmd/testrun_nfr.go
+++ b/cmd/testrun_nfr.go
@@ -38,5 +38,6 @@ func testRunNfrRun(cmd *cobra.Command, args []string) {
 		log.Fatal(err)
 	}
 
-	runNfrCheck(*client, testRunUID, fileName, file)
+	c := NfrChecker{Client: client, TestRunUID: testRunUID}
+	c.runNfrCheck(fileName, file)
 }

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -387,7 +387,7 @@ func (checker *NfrChecker) displayNfrResult(items testrun.NfrResultList) bool {
 	whiteBold := color.New(color.FgWhite, color.Bold).SprintFunc()
 
 	checkStatus := ""
-
+	anyFails := false
 	var success, total int
 	for _, item := range items.NfrResults {
 		total++ // we count everything, including disable and unavailable here.
@@ -400,6 +400,7 @@ func (checker *NfrChecker) displayNfrResult(items testrun.NfrResultList) bool {
 					checkStatus = green("\u2713")
 					actualSubject = fmt.Sprintf("was %s", item.SubjectWithUnit())
 				} else {
+					anyFails = true
 					checkStatus = red("\u2717")
 					actualSubject = fmt.Sprintf("but actually was %s", item.SubjectWithUnit())
 				}
@@ -435,7 +436,6 @@ func (checker *NfrChecker) displayNfrResult(items testrun.NfrResultList) bool {
 	}
 
 	fmt.Printf("%d/%d checks passed\n", success, total)
-	anyFails := success != total
 	if !anyFails {
 		fmt.Println(green("\nAll checks passed!"))
 	} else {


### PR DESCRIPTION
https://gramlabs.atlassian.net/browse/PERFTEST-46

#### Why?

When users execute a test-run with `--validate`, we are checking the report with a default NFR file to provide some quick and simple feedback for users if their test-run worked. Besides request errors, this nfr file also checks for the success rate of checks/assertions.

This confused our users regularly, as it this requirement fails since the default test-case we provide our users do not contain any checks/assertions. Thus just using default values leads to an error.

#### What?

This PR ignores the `checks` requirement in the nfr results, if the user uses our default nfr check and performs a validation run.

If the test-case contains any (even failing) checks or assertions, the checks line is kept.

### Example

```terminal
15:00 $ go run . test-case launch zeisss/sandbox --validate --region eu-central-1
Launching test zeisss/sandbox/92
UID: GPBrrjlg
Web URL: https://app.stormforger.com/tr/GPBrrjlg
Configuration: preflight cluster in eu-central-1
  [✓] Traffic Dump
  [✓] Session Validation Mode

Watching...
[status] Test Run: GPBrrjlg started not yet (est. end n/a)
[starting]
[done]
Test finished, running non-functional checks...
✓ test completion expected to be == true; was true (test.completed)
✓ HTTP error ratio expected to be == 0.0; was 0.0 (http.error_ratio)
2/2 checks passed

All checks passed!
```

