### PR TITLE
ci: Pin Ubuntu to 20.04 so forge binaries do not require newer GLIBC

### DIFF
--- a/.github/workflows/gobuild.yml
+++ b/.github/workflows/gobuild.yml
@@ -4,7 +4,7 @@ jobs:
 
   build:
     name: Build
-    runs-on: ubuntu-latest
+    runs-on: "ubuntu-20.04"
     steps:
     - name: Check out code
       uses: actions/checkout@v3
@@ -28,7 +28,7 @@ jobs:
 
   gofmt:
     name: Run gofmt
-    runs-on: ubuntu-latest
+    runs-on: "ubuntu-20.04"
     steps:
     - name: Check out code into the Go module directory
       uses: actions/checkout@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
       - "v*.*.*"
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: "ubuntu-20.04"
     name: goreleaser
     steps:
     - name: 'Wait for status checks'


### PR DESCRIPTION
We released a new `forge` version the other day. The release pipeline ran on Ubuntu 22.04 thus requiring the `forge` binary to require a newer GLIBC release.

This PR pins the release workflow to Ubuntu 20.04, thus making the binary compatible with older Ubuntu again (as well as the newest Ubuntu).