### PR TITLE
feat: Add forge tr share-url subcommand to create presigned URL for sharing reports

### DIFF
--- a/api/testrun.go
+++ b/api/testrun.go
@@ -361,7 +361,11 @@ func (c *Client) TestRunShareURL(ctx context.Context, testRunUID string, expireD
 
 	var responseData testrun.TestRunShareUrlResponse
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("unexpected status code %d, expected 200", resp.StatusCode)
+		payload, err := ErrorDecoder{}.UnmarshalErrorMeta(resp.Body)
+		if err != nil {
+			return nil, fmt.Errorf("unexpected status code %d, expected 200", resp.StatusCode)
+		}
+		return nil, fmt.Errorf("unexpected response: %s", payload.Message)
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&responseData); err != nil {
 		return nil, err

--- a/api/testrun.go
+++ b/api/testrun.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -340,14 +341,14 @@ func (c *Client) TestRunUnArchive(testRunUID string) (bool, []byte, error) {
 }
 
 // TestRunShareURL requests a shareable URL. A positive expireDuration is passed to the remote server.
-func (c *Client) TestRunShareURL(testRunUID string, expireDuration time.Duration) (*testrun.TestRunShareUrlResponse, error) {
+func (c *Client) TestRunShareURL(ctx context.Context, testRunUID string, expireDuration time.Duration) (*testrun.TestRunShareUrlResponse, error) {
 	payload := url.Values{}
 
 	if expireDuration != 0 {
 		payload.Add("expire_duration", fmt.Sprintf("%d", int(expireDuration.Seconds())))
 	}
 
-	req, err := http.NewRequest("POST", c.APIEndpoint+"/test_runs/"+url.PathEscape(testRunUID)+"/share_url", strings.NewReader(payload.Encode()))
+	req, err := http.NewRequestWithContext(ctx, "POST", c.APIEndpoint+"/test_runs/"+url.PathEscape(testRunUID)+"/share_url", strings.NewReader(payload.Encode()))
 	if err != nil {
 		return nil, err
 	}

--- a/api/testrun.go
+++ b/api/testrun.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -10,6 +11,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 
 	"github.com/google/jsonapi"
 	"github.com/stormforger/cli/api/testrun"
@@ -335,6 +337,35 @@ func (c *Client) TestRunUnArchive(testRunUID string) (bool, []byte, error) {
 	path := "/test_runs/" + testRunUID + "/unarchive"
 
 	return c.put(path, nil)
+}
+
+// TestRunShareURL requests a shareable URL. A positive expireDuration is passed to the remote server.
+func (c *Client) TestRunShareURL(testRunUID string, expireDuration time.Duration) (*testrun.TestRunShareUrlResponse, error) {
+	payload := url.Values{}
+
+	if expireDuration != 0 {
+		payload.Add("expire_duration", fmt.Sprintf("%d", int(expireDuration.Seconds())))
+	}
+
+	req, err := http.NewRequest("POST", c.APIEndpoint+"/test_runs/"+url.PathEscape(testRunUID)+"/share_url", strings.NewReader(payload.Encode()))
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.doRequestRaw(req)
+	if err != nil {
+		return nil, err
+	}
+	defer close(resp.Body)
+
+	var responseData testrun.TestRunShareUrlResponse
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status code %d, expected 200", resp.StatusCode)
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&responseData); err != nil {
+		return nil, err
+	}
+	return &responseData, nil
 }
 
 // ExtractTestRunResources will try to extract information to the

--- a/api/testrun/testrun.go
+++ b/api/testrun/testrun.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"reflect"
+	"time"
 
 	"github.com/google/jsonapi"
 )
@@ -58,6 +59,11 @@ type NfrResult struct {
 	Disabled         bool   `jsonapi:"attr,disabled"`
 	Filter           string `jsonapi:"attr,filter"`
 	Metric           string `jsonapi:"attr,metric"`
+}
+
+type TestRunShareUrlResponse struct {
+	URL       string     `json:"url"`
+	ExpiresAt *time.Time `json:"expires_at"`
 }
 
 // Unmarshal unmarshals a list of TestRun records

--- a/cmd/testrun_shareurl.go
+++ b/cmd/testrun_shareurl.go
@@ -36,7 +36,7 @@ func shareUrl(cmd *cobra.Command, args []string) {
 
 	testRunUID := getTestRunUID(*client, args[0])
 
-	shareURL, err := client.TestRunShareURL(testRunUID, shareURLOpts.ExpireDuration)
+	shareURL, err := client.TestRunShareURL(cmd.Context(), testRunUID, shareURLOpts.ExpireDuration)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/testrun_shareurl.go
+++ b/cmd/testrun_shareurl.go
@@ -1,0 +1,56 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	trShareURLCmd = &cobra.Command{
+		Use:     "share-url <test-run-ref>",
+		Aliases: []string{"shareurl"},
+		Args:    cobra.ExactArgs(1),
+		Short:   "Generate a share url for the testrun",
+		Example: "$ forge test-run share-url example-org/my-test-case/1\n" +
+			"$ forge test-run share-url a17fac2 --expire-duration 24h",
+		Run: shareUrl,
+	}
+
+	shareURLOpts struct {
+		ExpireDuration time.Duration
+	}
+)
+
+func init() {
+	TestRunCmd.AddCommand(trShareURLCmd)
+
+	trShareURLCmd.Flags().DurationVar(&shareURLOpts.ExpireDuration, "expire-duration", 0, "Expire duration for this token - zero leaves this up to the server")
+}
+
+func shareUrl(cmd *cobra.Command, args []string) {
+	client := NewClient()
+
+	testRunUID := getTestRunUID(*client, args[0])
+
+	shareURL, err := client.TestRunShareURL(testRunUID, shareURLOpts.ExpireDuration)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	switch rootOpts.OutputFormat {
+	case "json":
+		enc := json.NewEncoder(cmd.OutOrStdout())
+		enc.SetIndent("", "  ")
+		enc.Encode(shareURL)
+	default:
+		fmt.Println("URL:\t\t", shareURL.URL)
+		if shareURL.ExpiresAt != nil && !shareURL.ExpiresAt.IsZero() {
+			fmt.Println("Expires at:\t", shareURL.ExpiresAt.Format(time.RFC3339))
+		}
+	}
+
+}


### PR DESCRIPTION
This adds a new subommand:

```terminal
forge test-run share-url my-org/demo/1
```

Optionally, the `--expire-duration` flag can be provided to customize the duration of the signed share url. By default, the expire-duration is determined by the API, which currently defaults to 1 year.

#### Example


```terminal
$ forge tr share-url foo/test_simple/7  --output json
{
  "url": "http://localhost:3000/s/tr:8wg8kxwg:test_simple:7?token=eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0cjo4d2c4a3h3ZyIsImV4cCI6MTcxODk5MjAwOCwiaWF0IjoxNjg3NDM1MDU2LCJqdGkiOiI4YjNiZmQiLCJzZl9jYnkiOiJ5dHlreWl2YiJ9.uF7u1T7TpPVhJMRlWrzcl4VGhggLeF-vL0wDtwNJLu8",
  "expires_at": "2024-06-21T17:46:48Z"
}

$ forge tr share-url foo/test_simple/7
URL:		 http://localhost:3000/s/tr:8wg8kxwg:test_simple:7?token=eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0cjo4d2c4a3h3ZyIsImV4cCI6MTcxODk5MjAxMiwiaWF0IjoxNjg3NDM1MDYwLCJqdGkiOiI4YjNiZmQiLCJzZl9jYnkiOiJ5dHlreWl2YiJ9.RnF4lLgK8v7uD3D0A9AYJJASLI9KreV4RF1QsJyqbRI
Expires at:	 2024-06-21T17:46:52Z
```

If you pass an invalid value:

```terminal
$ forge tr share-url foo/test_simple/7  --expire-duration 999999h
2023/06/23 11:30:02 unexpected response: Param 'expire_duration' must be between 1 and 31556952

$ forge tr share-url foo/test_simple/7  --expire-duration -1s
2023/06/23 11:30:06 unexpected response: Param 'expire_duration' must be between 1 and 31556952

```