### PR TITLE
fix: Update bundle tests to have proper example

### DIFF
--- a/cmd/testcase_build_test.go
+++ b/cmd/testcase_build_test.go
@@ -23,7 +23,7 @@ func TestTestcaseBuild(t *testing.T) {
 func TestTestcaseBuild__DefineParam(t *testing.T) {
 	var expectedOutput = GivenTestdataContents(t, t.Name()+"_output.js")
 	defines := map[string]string{
-		"ENV": "\"production\"", // DOUBLE QUOTING!
+		"defines.target": "\"http://example.com\"", // DOUBLE QUOTING!
 	}
 
 	var output strings.Builder

--- a/cmd/testdata/TestTestcaseBuild__DefineParam_main.mjs
+++ b/cmd/testdata/TestTestcaseBuild__DefineParam_main.mjs
@@ -3,4 +3,5 @@ var config = {
   target: defines.target || "http://testapp.loadtest.party"
 }
 
+definition.setArrivalPhases([{duration: 60, rate: 0,}]);
 definition.addTarget(config.target);

--- a/cmd/testdata/TestTestcaseBuild__DefineParam_main.mjs
+++ b/cmd/testdata/TestTestcaseBuild__DefineParam_main.mjs
@@ -1,5 +1,6 @@
-const config = {
-  env: ENV || "staging",
+defines = {}
+var config = {
+  target: defines.target || "http://testapp.loadtest.party"
 }
 
-definition.addTarget(env);
+definition.addTarget(config.target);

--- a/cmd/testdata/TestTestcaseBuild__DefineParam_main.mjs
+++ b/cmd/testdata/TestTestcaseBuild__DefineParam_main.mjs
@@ -1,5 +1,5 @@
 defines = {}
-var config = {
+const config = {
   target: defines.target || "http://testapp.loadtest.party"
 }
 

--- a/cmd/testdata/TestTestcaseBuild__DefineParam_output.js
+++ b/cmd/testdata/TestTestcaseBuild__DefineParam_output.js
@@ -1,2 +1,6 @@
 // testdata/TestTestcaseBuild__DefineParam_main.mjs
-definition.addTarget(env);
+defines = {};
+var config = {
+  target: "http://example.com"
+};
+definition.addTarget(config.target);

--- a/cmd/testdata/TestTestcaseBuild__DefineParam_output.js
+++ b/cmd/testdata/TestTestcaseBuild__DefineParam_output.js
@@ -3,4 +3,5 @@ defines = {};
 var config = {
   target: "http://example.com"
 };
+definition.setArrivalPhases([{ duration: 60, rate: 0 }]);
 definition.addTarget(config.target);

--- a/cmd/testdata/TestTestcaseBuild__WithUndefinedVariable_main.mjs
+++ b/cmd/testdata/TestTestcaseBuild__WithUndefinedVariable_main.mjs
@@ -3,4 +3,5 @@ var config = {
   target: defines.target || "http://testapp.loadtest.party"
 }
 
+definition.setArrivalPhases([{duration: 60, rate: 0,}]);
 definition.addTarget(config.target);

--- a/cmd/testdata/TestTestcaseBuild__WithUndefinedVariable_main.mjs
+++ b/cmd/testdata/TestTestcaseBuild__WithUndefinedVariable_main.mjs
@@ -1,5 +1,6 @@
-const config = {
-  env: ENV || "staging", // Intentionally undefined in the go test
+defines = {}
+var config = {
+  target: defines.target || "http://testapp.loadtest.party"
 }
 
-definition.addTarget(env);
+definition.addTarget(config.target);

--- a/cmd/testdata/TestTestcaseBuild__WithUndefinedVariable_main.mjs
+++ b/cmd/testdata/TestTestcaseBuild__WithUndefinedVariable_main.mjs
@@ -1,5 +1,5 @@
 defines = {}
-var config = {
+const config = {
   target: defines.target || "http://testapp.loadtest.party"
 }
 

--- a/cmd/testdata/TestTestcaseBuild__WithUndefinedVariable_output.js
+++ b/cmd/testdata/TestTestcaseBuild__WithUndefinedVariable_output.js
@@ -3,4 +3,5 @@ defines = {};
 var config = {
   target: defines.target || "http://testapp.loadtest.party"
 };
+definition.setArrivalPhases([{ duration: 60, rate: 0 }]);
 definition.addTarget(config.target);

--- a/cmd/testdata/TestTestcaseBuild__WithUndefinedVariable_output.js
+++ b/cmd/testdata/TestTestcaseBuild__WithUndefinedVariable_output.js
@@ -1,6 +1,6 @@
 // testdata/TestTestcaseBuild__WithUndefinedVariable_main.mjs
+defines = {};
 var config = {
-  env: ENV || "staging"
-  // Intentionally undefined in the go test
+  target: defines.target || "http://testapp.loadtest.party"
 };
-definition.addTarget(env);
+definition.addTarget(config.target);

--- a/testdata/cases/index.mjs
+++ b/testdata/cases/index.mjs
@@ -1,8 +1,8 @@
 import "./modules/options.js"
 import scenario from "./modules/scenario.js"
 
-// NOTE: No 'var' or 'const' for defines!!!
-// Inject defines here with '--define defines.env="prod"'
+// NOTE: `--define` works on global identifiers only! To make `defines` a global identifier, it MUST NOT be defined via `var`/`let`/`const`.
+// To replace fields of `defines`, use '--define defines.env="prod"'
 defines = {};
 var config = {
   env: defines.env || "staging",

--- a/testdata/cases/index.mjs
+++ b/testdata/cases/index.mjs
@@ -1,10 +1,13 @@
 import "./modules/options.js"
 import scenario from "./modules/scenario.js"
 
-// TODO do we want a "convention" here? An object
-// that can be used to replace value into, would be a start…
-const config = {
-  env: ENV || "staging",
+// NOTE: No 'var' or 'const' for defines!!!
+// Inject defines here with '--define defines.env="prod"'
+defines = {};
+var config = {
+  env: defines.env || "staging",
+  target: defines.target || "https://testapp.loadtest.party",
 }
 
-definition.session("hello", scenario(config))
+definition.addTarget(config.target)
+definition.session("hello", scenario(config.env))

--- a/testdata/cases/modules/options.js
+++ b/testdata/cases/modules/options.js
@@ -1,5 +1,3 @@
-definition.addTarget("testapp.loadtest.party")
-
 definition.setArrivalPhases([{
     duration: 60,
     rate: 42,


### PR DESCRIPTION
Once upon a time we added some bundling tests in #304 which did not properly represent passing in values while also having a valid test case if not defining a value.

This PR updates the test-cases and the modules example to have a case that works when passing values via `--define` but also allows skipping those values.