### PR TITLE
Pin GH Actions

### DIFF
--- a/.github/workflows/gobuild.yml
+++ b/.github/workflows/gobuild.yml
@@ -10,7 +10,7 @@ jobs:
       uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
 
     - name: Set up Go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
       with:
         go-version-file: "go.mod"
 
@@ -34,7 +34,7 @@ jobs:
       uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
 
     - name: Set up Go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
       with:
         go-version-file: "go.mod"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,41 +10,32 @@ jobs:
     runs-on: "ubuntu-20.04"
     name: goreleaser
     steps:
-    - name: 'Wait for status checks'
-      uses: jitterbit/await-check-suites@v1
-      with:
-        token: "${{ secrets.GITHUB_TOKEN }}"
-        timeoutSeconds: 600
-        appSlugFilter: 'github-actions'
+      - name: "Wait for status checks"
+        uses: jitterbit/await-check-suites@292a541bb7618078395b2ce711a0d89cfb8a568a # v1
+        with:
+          token: "${{ secrets.GITHUB_TOKEN }}"
+          timeoutSeconds: 600
+          appSlugFilter: "github-actions"
 
-    - name: Check out code
-      uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
-      with:
-        fetch-depth: 0
+      - name: Check out code
+        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+        with:
+          fetch-depth: 0
 
-    - name: Set up Go
-      uses: actions/setup-go@v4
-      with:
-        go-version-file: "go.mod"
+      - name: Set up Go
+        uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
+        with:
+          go-version-file: "go.mod"
 
-    - uses: actions/cache@v3
-      with:
-        path: |
-          ~/go/pkg/mod
-          ~/.cache/go-build
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go-
+      - name: docker login
+        run: docker login -u="${{ secrets.DOCKER_USERNAME }}" -p="${{ secrets.DOCKER_PASSWORD }}"
 
-    - name: docker login
-      run: docker login -u="${{ secrets.DOCKER_USERNAME }}" -p="${{ secrets.DOCKER_PASSWORD }}"
+      - name: Release via goreleaser
+        uses: goreleaser/goreleaser-action@7ec5c2b0c6cdda6e8bbb49444bc797dd33d74dd8 # v5.0.0
+        with:
+          args: release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_GORELEASER_TOKEN }}
 
-    - name: Release via goreleaser
-      uses: goreleaser/goreleaser-action@master
-      with:
-        args: release
-      env:
-        GITHUB_TOKEN: ${{ secrets.GH_GORELEASER_TOKEN }}
-
-    - name: Ping Forge to check for new Versions
-      run: curl -d '' https://app.stormforger.com/cli_releases/refresh --user-agent "StormForger Github Action Pipeline" --user ":${{ secrets.FORGE_EXTERNAL_ACCESS_BASIC_AUTH_SECRET }}" --fail
+      - name: Ping Forge to check for new Versions
+        run: curl -d '' https://app.stormforger.com/cli_releases/refresh --user-agent "StormForger Github Action Pipeline" --user ":${{ secrets.FORGE_EXTERNAL_ACCESS_BASIC_AUTH_SECRET }}" --fail


### PR DESCRIPTION
Pin all GH actions to their exact commit SHA.

Also: Removed the manual use of `actions/cache`, as this is no longer needed since [`actions/setup-go@v4`](https://github.com/actions/setup-go#v4):

> The action will try to enable caching unless the cache input is explicitly set to false.