### PR TITLE
GHA: Update runner OS, drop jitterbit/await-check-suites

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,5 +1,8 @@
 name: Go
-on: [push]
+on:
+  push:
+  # Also allow this workflow to be callable.
+  workflow_call:
 jobs:
   build:
     name: Build

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -6,7 +6,8 @@ on:
 jobs:
   build:
     name: Build
-    runs-on: "ubuntu-22.04"
+    # stick with Ubuntu 20.04 LTS for older glibc compatibility
+    runs-on: "ubuntu-20.04"
     steps:
     - name: Check out code
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,7 +1,6 @@
 name: Go
 on: [push]
 jobs:
-
   build:
     name: Build
     runs-on: "ubuntu-20.04"

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -3,7 +3,7 @@ on: [push]
 jobs:
   build:
     name: Build
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-22.04"
     steps:
     - name: Check out code
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,8 @@ jobs:
     secrets: inherit
 
   build:
-    runs-on: "ubuntu-22.04"
+    # stick with Ubuntu 20.04 LTS for older glibc compatibility
+    runs-on: "ubuntu-20.04"
     name: goreleaser
     needs: buildandtest
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,17 +6,15 @@ on:
     tags:
       - "v*.*.*"
 jobs:
+  buildandtest:
+    uses: ./.github/workflows/go.yml
+    secrets: inherit
+
   build:
     runs-on: "ubuntu-20.04"
     name: goreleaser
+    needs: buildandtest
     steps:
-      - name: "Wait for status checks"
-        uses: jitterbit/await-check-suites@292a541bb7618078395b2ce711a0d89cfb8a568a # v1
-        with:
-          token: "${{ secrets.GITHUB_TOKEN }}"
-          timeoutSeconds: 600
-          appSlugFilter: "github-actions"
-
       - name: Check out code
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     secrets: inherit
 
   build:
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-22.04"
     name: goreleaser
     needs: buildandtest
     steps:


### PR DESCRIPTION
* ~update runner to Ubuntu 22.04 LTS~ we don't want to - I added a comment why
* renames `gobuild.yml` -> `go.yml` for consistency with other repos
* drops `jitterbit/await-check-suites` (which is unmaintained and outdated) and just re-build