### PR TITLE
fix(testcase create): Do not relie on empty errors array to check for success

### DIFF
--- a/api/testcase.go
+++ b/api/testcase.go
@@ -114,7 +114,7 @@ func (c *Client) TestCaseUpdate(testCaseUID string, fileName string, data io.Rea
 
 	defer close(response.Body)
 
-	if response.StatusCode != 200 {
+	if response.StatusCode >= 300 {
 		return false, string(body), nil
 	}
 

--- a/api/testcase.go
+++ b/api/testcase.go
@@ -81,7 +81,7 @@ func (c *Client) TestCaseCreate(organization string, testCaseName string, fileNa
 
 	defer close(response.Body)
 
-	if response.StatusCode != 200 {
+	if response.StatusCode >= 300 {
 		return false, string(body), nil
 	}
 

--- a/cmd/testcase_create.go
+++ b/cmd/testcase_create.go
@@ -111,7 +111,10 @@ func runTestCaseCreate(cmd *cobra.Command, args []string) {
 		errValidation error
 	)
 	if testcaseUID != "" && !testCaseCreateOpts.Update {
-		log.Fatal("Test-Case already exists.")
+		printErrorPayloadHuman(os.Stderr, false, api.ErrorPayload{
+			Message: "Test-Case already exists.",
+		})
+		cmdExit(false)
 	} else if testcaseUID == "" {
 		success, message, errValidation = client.TestCaseCreate(orgaUID, testCaseName, bundle.Name, bundle.Content)
 	} else {

--- a/cmd/testcase_create.go
+++ b/cmd/testcase_create.go
@@ -135,6 +135,6 @@ func runTestCaseCreate(cmd *cobra.Command, args []string) {
 		log.Fatal(err)
 	}
 
-	printValidationResultHuman(os.Stderr, success, errorMeta)
+	printErrorPayloadHuman(os.Stderr, success, errorMeta)
 	cmdExit(success)
 }

--- a/cmd/testcase_create.go
+++ b/cmd/testcase_create.go
@@ -132,10 +132,6 @@ func runTestCaseCreate(cmd *cobra.Command, args []string) {
 		log.Fatal(err)
 	}
 
-	if len(errorMeta.Errors) == 0 {
-		os.Exit(0)
-	}
-
 	printValidationResultHuman(os.Stderr, success, errorMeta)
 	cmdExit(success)
 }

--- a/cmd/testcase_launch.go
+++ b/cmd/testcase_launch.go
@@ -232,7 +232,7 @@ func MainTestRunLaunch(client *api.Client, testCaseSpec string, testRunLaunchOpt
 			log.Fatal(err)
 		}
 
-		printValidationResultHuman(os.Stderr, status, errorMeta)
+		printErrorPayloadHuman(os.Stderr, status, errorMeta)
 		cmdExit(status)
 	}
 

--- a/cmd/testcase_update.go
+++ b/cmd/testcase_update.go
@@ -90,7 +90,7 @@ func runTestCaseUpdate(cmd *cobra.Command, args []string) {
 		log.Fatal(err)
 	}
 
-	printValidationResultHuman(os.Stderr, success, errorMeta)
+	printErrorPayloadHuman(os.Stderr, success, errorMeta)
 	cmdExit(success)
 }
 
@@ -106,7 +106,7 @@ func printValidationResultJSON(message string) {
 	fmt.Println(message)
 }
 
-func printValidationResultHuman(fp io.Writer, success bool, errorMeta api.ErrorPayload) {
+func printErrorPayloadHuman(fp io.Writer, success bool, errorMeta api.ErrorPayload) {
 	prefix := "INFO"
 	if !success {
 		prefix = color.RedString("ERROR")

--- a/cmd/testcase_update_test.go
+++ b/cmd/testcase_update_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestPrintValidationResultHuman_NoErrors(t *testing.T) {
 	var buf strings.Builder
-	printValidationResultHuman(&buf, true, api.ErrorPayload{
+	printErrorPayloadHuman(&buf, true, api.ErrorPayload{
 		Message: "TestCase updated.",
 	})
 	assert.Equal(t, buf.String(), "INFO: TestCase updated.\n")
@@ -18,7 +18,7 @@ func TestPrintValidationResultHuman_NoErrors(t *testing.T) {
 
 func TestPrintValidationResultHuman_ValidationErrors(t *testing.T) {
 	var buf strings.Builder
-	printValidationResultHuman(&buf, true, api.ErrorPayload{
+	printErrorPayloadHuman(&buf, true, api.ErrorPayload{
 		Message: "TestCase updated, but validation errors occured.",
 		Errors: []api.ErrorDetail{
 			{Code: "E0", Title: "Validation Error"},
@@ -29,7 +29,7 @@ func TestPrintValidationResultHuman_ValidationErrors(t *testing.T) {
 
 func TestPrintValidationResultHuman_Error(t *testing.T) {
 	var buf strings.Builder
-	printValidationResultHuman(&buf, false, api.ErrorPayload{
+	printErrorPayloadHuman(&buf, false, api.ErrorPayload{
 		Message: "TestCase update failed.",
 		Errors: []api.ErrorDetail{
 			{Code: "E0", Title: "Error"},

--- a/cmd/testcase_validate.go
+++ b/cmd/testcase_validate.go
@@ -118,6 +118,6 @@ func runTestCaseValidateArg(cmd *cobra.Command, client *api.Client, fileOrStdin 
 		return false, err
 	}
 
-	printValidationResultHuman(os.Stderr, success, errorMeta)
+	printErrorPayloadHuman(os.Stderr, success, errorMeta)
 	return success, nil
 }


### PR DESCRIPTION
Two smaller fixes:

* `forge tc create` did not print an error nor had a non-zero test-case for some API calls where we only returned a message, but nothing in the `errors` field. This will now always print the result
* Treat any 2xx as success for API TestcaseCreate()
* Cleanup feedback printing a bit