### PR TITLE
fix(api): Sent user-agent for login as well

### DIFF
--- a/api/file_fixture.go
+++ b/api/file_fixture.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 )
@@ -31,7 +30,7 @@ func (c *Client) MoveFileFixture(organization string, fileFixtureUID string, new
 	}
 	defer response.Body.Close()
 
-	body, err := ioutil.ReadAll(response.Body)
+	body, err := io.ReadAll(response.Body)
 	if err != nil {
 		return false, "", err
 	}
@@ -83,7 +82,7 @@ func (c *Client) PushFileFixture(fileName string, data io.Reader, organization s
 	}
 	defer response.Body.Close()
 
-	body, err := ioutil.ReadAll(response.Body)
+	body, err := io.ReadAll(response.Body)
 	if err != nil {
 		return false, nil, err
 	}
@@ -110,7 +109,7 @@ func (c *Client) DeleteFileFixture(fileFixtureUID string, organization string) (
 	}
 	defer response.Body.Close()
 
-	body, err := ioutil.ReadAll(response.Body)
+	body, err := io.ReadAll(response.Body)
 	if err != nil {
 		return false, "", err
 	}

--- a/api/har.go
+++ b/api/har.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/url"
 )
 
@@ -14,7 +13,7 @@ import (
 func (c *Client) Har(fileName string, data io.Reader) (string, error) {
 	extraParams := url.Values{}
 
-	input, err := ioutil.ReadAll(data)
+	input, err := io.ReadAll(data)
 	if err != nil {
 		return "", fmt.Errorf("%s: %v", fileName, err)
 	}
@@ -33,7 +32,7 @@ func (c *Client) Har(fileName string, data io.Reader) (string, error) {
 		return "", err
 	}
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", err
 	}

--- a/api/har.go
+++ b/api/har.go
@@ -27,6 +27,8 @@ func (c *Client) Har(fileName string, data io.Reader) (string, error) {
 		return "", err
 	}
 
+	c.setUserAgent(req)
+
 	resp, err := c.HTTPClient.Do(req)
 	if err != nil {
 		return "", err

--- a/api/login.go
+++ b/api/login.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
-	"io/ioutil"
+	"io"
 	"net/http"
 )
 
@@ -12,18 +12,19 @@ import (
 func (c *Client) Login(email string, password string) (string, error) {
 	data := map[string]string{"email": email, "password": password}
 
-	body := new(bytes.Buffer)
-	err := json.NewEncoder(body).Encode(data)
+	var body bytes.Buffer
+	err := json.NewEncoder(&body).Encode(data)
 	if err != nil {
 		return "", err
 	}
 
-	req, err := http.NewRequest("POST", c.APIEndpoint+"/user/token", body)
+	req, err := http.NewRequest("POST", c.APIEndpoint+"/user/token", &body)
 	if err != nil {
 		return "", err
 	}
 
 	req.Header.Set("Content-Type", "application/json")
+	c.setUserAgent(req)
 
 	resp, err := c.HTTPClient.Do(req)
 	if err != nil {
@@ -32,7 +33,7 @@ func (c *Client) Login(email string, password string) (string, error) {
 
 	defer close(resp.Body)
 
-	responseBody, err := ioutil.ReadAll(resp.Body)
+	responseBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", err
 	}

--- a/api/serviceaccount.go
+++ b/api/serviceaccount.go
@@ -2,7 +2,7 @@ package api
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -31,7 +31,7 @@ func (c *Client) CreateServiceAccount(org, token_label string) (bool, string, er
 	}
 	defer response.Body.Close()
 
-	body, err := ioutil.ReadAll(response.Body)
+	body, err := io.ReadAll(response.Body)
 	if err != nil {
 		return false, "", err
 	}

--- a/api/testcase.go
+++ b/api/testcase.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"io"
-	"io/ioutil"
 	"net/url"
 )
 
@@ -40,7 +39,7 @@ func (c *Client) TestCaseValidate(organization string, fileName string, data io.
 	}
 	defer response.Body.Close()
 
-	body, err := ioutil.ReadAll(response.Body)
+	body, err := io.ReadAll(response.Body)
 	if err != nil {
 		return false, "", err
 	}
@@ -74,7 +73,7 @@ func (c *Client) TestCaseCreate(organization string, testCaseName string, fileNa
 	}
 	defer response.Body.Close()
 
-	body, err := ioutil.ReadAll(response.Body)
+	body, err := io.ReadAll(response.Body)
 	if err != nil {
 		return false, "", err
 	}
@@ -107,7 +106,7 @@ func (c *Client) TestCaseUpdate(testCaseUID string, fileName string, data io.Rea
 	}
 	defer response.Body.Close()
 
-	body, err := ioutil.ReadAll(response.Body)
+	body, err := io.ReadAll(response.Body)
 	if err != nil {
 		return false, "", err
 	}

--- a/api/testrun.go
+++ b/api/testrun.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"net/url"
@@ -86,7 +85,7 @@ func (c *Client) TestRunWatch(uid string) (testrun.TestRun, string, error) {
 	}
 	defer response.Body.Close()
 
-	body, err := ioutil.ReadAll(response.Body)
+	body, err := io.ReadAll(response.Body)
 	if err != nil {
 		return testrun.TestRun{}, "", err
 	}
@@ -239,7 +238,7 @@ func (c *Client) TestRunCreate(testCaseUID string, options TestRunLaunchOptions)
 	}
 	defer response.Body.Close()
 
-	body, err := ioutil.ReadAll(response.Body)
+	body, err := io.ReadAll(response.Body)
 	if err != nil {
 		return false, "", err
 	}
@@ -263,7 +262,7 @@ func (c *Client) TestRunAbort(testRunUID string) (bool, string, error) {
 	}
 	defer response.Body.Close()
 
-	body, err := ioutil.ReadAll(response.Body)
+	body, err := io.ReadAll(response.Body)
 	if err != nil {
 		return false, "", err
 	}
@@ -290,7 +289,7 @@ func (c *Client) TestRunAbortAll(organisationUID string) (bool, string, error) {
 
 	defer close(resp.Body)
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return false, "", err
 	}
@@ -316,7 +315,7 @@ func (c *Client) TestRunNfrCheck(uid string, fileName string, data io.Reader) (b
 	}
 	defer response.Body.Close()
 
-	body, err := ioutil.ReadAll(response.Body)
+	body, err := io.ReadAll(response.Body)
 	if err != nil {
 		return false, nil, err
 	}

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -62,7 +61,7 @@ func runLogin(cmd *cobra.Command, args []string) {
 				log.Fatal(err)
 			}
 
-			err = ioutil.WriteFile(stormforgerConfig, content, 0644)
+			err = os.WriteFile(stormforgerConfig, content, 0644)
 			if err != nil {
 				log.Fatal(err)
 			}

--- a/cmd/testcase_build_test.go
+++ b/cmd/testcase_build_test.go
@@ -1,7 +1,7 @@
 package cmd
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -48,7 +48,7 @@ func TestTestcaseBuild__WithUndefinedVariable(t *testing.T) {
 func GivenTestdataContents(t *testing.T, file string) string {
 	p := filepath.Join("testdata", file)
 
-	data, err := ioutil.ReadFile(p)
+	data, err := os.ReadFile(p)
 	require.NoError(t, err)
 
 	return string(data)

--- a/cmd/testcase_get.go
+++ b/cmd/testcase_get.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 
@@ -56,7 +55,7 @@ func runTestCaseGet(cmd *cobra.Command, args []string) {
 	}
 
 	if len(args) == 2 && args[1] != "-" {
-		err := ioutil.WriteFile(args[1], response, 0644)
+		err := os.WriteFile(args[1], response, 0644)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/cmd/testcase_launch.go
+++ b/cmd/testcase_launch.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -243,7 +242,7 @@ func MainTestRunLaunch(client *api.Client, testCaseSpec string, testRunLaunchOpt
 
 	if testRunLaunchOpts.TestRunIDOutputFile != "" {
 		f := testRunLaunchOpts.TestRunIDOutputFile
-		err := ioutil.WriteFile(f, []byte(testRun.ID), 0644)
+		err := os.WriteFile(f, []byte(testRun.ID), 0644)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Failed to write file: %v\n", err)
 			os.Exit(1)


### PR DESCRIPTION
We noticed that we still send the default Go user agent string `go-http-client/???` for logins.

This PR fixes this as well as usage of the deprecated `io/ioutil`.