### PR TITLE
fix: forge ping returns an exit code when ping fails

### DIFF
--- a/cmd/ping.go
+++ b/cmd/ping.go
@@ -72,6 +72,9 @@ func runPingCmd(cmd *cobra.Command, args []string) {
 		Subject:         user,
 	}
 	printPingCommandResult(os.Stdout, result)
+	if !result.Success {
+		os.Exit(1)
+	}
 }
 
 func PrintHumanPingResult(w io.Writer, result PingCommandResult) {


### PR DESCRIPTION
A user reported that their CI pipeline continued working although the `forge ping` command printed an error.

Expected behavior is for the `forge ping` command to have a non-zero exit code.