### PR TITLE
chore(dependabot): Switch to monthly update schedule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,8 +3,8 @@ updates:
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"


### PR DESCRIPTION
We are currently don't need to do many changes to the CLI, so we rarely do releases. There is no need to merge every single dependency update with so few releases. Lets switch to a monthly schedule to stay up to date.

We can still manually run the updates before doing an actual release.